### PR TITLE
Change SUT environment to Production

### DIFF
--- a/test/FunctionalTests/Fixture/WebApiFactory.cs
+++ b/test/FunctionalTests/Fixture/WebApiFactory.cs
@@ -1,7 +1,13 @@
-﻿using Microsoft.AspNetCore.Mvc.Testing;
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Hosting;
 
 namespace MoneyGroup.FunctionalTests.Fixture;
 
 public sealed class WebApiFactory : WebApplicationFactory<Program>
 {
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment(Environments.Production);
+    }
 }


### PR DESCRIPTION

This pull request includes changes to the `test/FunctionalTests/Fixture/WebApiFactory.cs` file to enhance the configuration of the web host environment for functional tests.

Configuration improvements:

* [`test/FunctionalTests/Fixture/WebApiFactory.cs`](diffhunk://#diff-ac74774537aba6ac816ec6d03cc21f1fb4a574c7ba446d3aef949c798de11cb9L1-R12): Added the `ConfigureWebHost` method to set the environment to production using `builder.UseEnvironment(Environments.Production)`.