### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,14 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+
+  - package-ecosystem: "dotnet-sdk"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    ignore:
+      - dependency-name: "*"
+        update-types: 
+          - "version-update:semver-major"
+          - "version-update:semver-minor"


### PR DESCRIPTION
This pull request includes a change to the `.github/dependabot.yml` file to add a new update schedule for the `dotnet-sdk` package ecosystem.

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R35-R45): Added a weekly update schedule for the `dotnet-sdk` package ecosystem, set to run on Wednesdays and ignoring major and minor version updates.