### PR TITLE
Add xUnit report generation to test command in CI workflows

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -64,14 +64,14 @@ jobs:
       shell: pwsh
       run: |
         docker compose up --wait
-        dotnet test MoneyGroup.sln -c Release --no-build --verbosity normal -- --coverage --coverage-settings $pwd/coverage.config --coverage-output-format xml
+        dotnet test MoneyGroup.sln -c Release --no-build --verbosity normal -- --coverage --coverage-settings $pwd/coverage.config --coverage-output-format xml --report-xunit
 
     - name: End Analyze
       env:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       shell: pwsh
       run: |
-        dotnet coverage merge **/TestResults/** --output coverage.xml --output-format xml
+        dotnet coverage merge **/TestResults/**.xml --output coverage.xml --output-format xml
         dotnet sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
 
     - name: Upload TestResults Artifacts


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/dotnet.yml` file to improve the test and coverage reporting.

Improvements to test and coverage reporting:

* Modified the `dotnet test` command to include the `--report-xunit` option for generating test reports in xUnit format.
* Changed the `dotnet coverage merge` command to ensure it processes only XML files by adding the `.xml` extension to the file pattern.