### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    # groups:
+    groups:
+      all:
+        patterns:
+          - *
     #   microsoft:
     #     patterns:
     #       - "Microsoft.*"


### PR DESCRIPTION
This pull request includes a change to the `.github/dependabot.yml` file to enable grouping of dependencies. The most important change is the addition of a new group named `all` that matches all dependency patterns.

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L20-R23): Added a new group named `all` to match all dependency patterns.