### PR TITLE
Update dotnet.yml

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,7 +2,7 @@ name: .NET CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
     paths:
       - src/
       - test/


### PR DESCRIPTION
This pull request includes a change to the `.NET CI` workflow configuration file to ensure that the CI pipeline runs on both the `main` and `dev` branches.

* [`.github/workflows/dotnet.yml`](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344L5-R5): Updated the `branches` configuration to include both `main` and `dev` branches.