### PR TITLE
Fix path configurations in CI workflow files

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,7 +11,7 @@ on:
   push:
     branches: [ "main" ]
     paths:
-      - src/
+      - src/**
       - .github/workflows/docker-publish.yml
       - global.json
       - Directory.Build.props
@@ -22,7 +22,7 @@ on:
   pull_request:
     branches: [ "main" ]
     paths:
-      - src/
+      - src/**
       - .github/workflows/docker-publish.yml
       - global.json
       - Directory.Build.props

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches: [ "main", "dev" ]
     paths:
-      - src/
-      - test/
+      - src/**
+      - test/**
       - .github/workflows/dotnet.yml
       - .config/dotnet-tools.json
       - global.json
@@ -16,8 +16,8 @@ on:
   pull_request:
     branches: [ "main" ]
     paths:
-      - src/
-      - test/
+      - src/**
+      - test/**
       - .github/workflows/dotnet.yml
       - .config/dotnet-tools.json
       - global.json


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflows to ensure that all files within the `src` and `test` directories trigger the workflows, not just the top-level files. The most important changes are listed below:

Changes to `.github/workflows/docker-publish.yml`:

* Updated the paths configuration to include all files within the `src` directory for both `push` and `pull_request` events. [[1]](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L14-R14) [[2]](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L25-R25)

Changes to `.github/workflows/dotnet.yml`:

* Updated the paths configuration to include all files within the `src` and `test` directories for both `push` and `pull_request` events. [[1]](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344L7-R8) [[2]](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344L19-R20)