### PR TITLE
Fix #153: Refactor to use `ProblemDetails` instead

### DIFF
--- a/src/WebApi/Middlewares/BusinessValidationExceptionHandler.cs
+++ b/src/WebApi/Middlewares/BusinessValidationExceptionHandler.cs
@@ -17,7 +17,7 @@ public class BusinessValidationExceptionHandler(IProblemDetailsService problemDe
             return false;
         }
 
-        var validationProblemDetails = new ValidationProblemDetails()
+        var problemDetails = new ProblemDetails()
         {
             Detail = validationException.Message,
         };
@@ -27,7 +27,7 @@ public class BusinessValidationExceptionHandler(IProblemDetailsService problemDe
         await _problemDetailsService.WriteAsync(new ProblemDetailsContext
         {
             HttpContext = httpContext,
-            ProblemDetails = validationProblemDetails,
+            ProblemDetails = problemDetails,
             Exception = validationException,
         });
 


### PR DESCRIPTION
This pull request includes a change to the `src/WebApi/Middlewares/BusinessValidationExceptionHandler.cs` file. The change modifies the type of the `validationProblemDetails` variable to use `ProblemDetails` instead of `ValidationProblemDetails`.

* [`src/WebApi/Middlewares/BusinessValidationExceptionHandler.cs`](diffhunk://#diff-2c5f9325f87aceb84755af9a540824648ffaec5f9ed97878e2082372793ce268L20-R20): Changed the type of `validationProblemDetails` from `ValidationProblemDetails` to `ProblemDetails` in the `TryHandleAsync` method.