### PR TITLE
chore(tests): update path separator in test configuration for code coverage exclusion

### DIFF
--- a/testconfig.json
+++ b/testconfig.json
@@ -5,7 +5,7 @@
             "CodeCoverage": {
                 "Sources": {
                     "Exclude": [
-                        ".*\\\\Migrations\\\\.*.cs"
+                        ".*\\/Migrations\\/.*.cs"
                     ]
                 }
             }


### PR DESCRIPTION
This pull request makes a minor update to the code coverage configuration to ensure migration files are properly excluded for code coverage analysis.

* Updated the exclusion pattern for migration files in `testconfig.json` from a Windows-style path (`\`) to a Unix-style path (`/`) to improve cross-platform compatibility.