### PR TITLE
Refactor/correct dependencies

### DIFF
--- a/src/Core/MoneyGroup.Core.csproj
+++ b/src/Core/MoneyGroup.Core.csproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="Ardalis.Specification" />
-    <PackageReference Include="FluentValidation" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 

--- a/src/Core/packages.lock.json
+++ b/src/Core/packages.lock.json
@@ -8,12 +8,6 @@
         "resolved": "9.3.1",
         "contentHash": "GWrE6BA0smWFLbN+XPU2l5rDF9Uzelfbb3w35jJ0CGIat+p1ChbtLcbkvYRMEculBHOAo12omwAAOm3VFWkoJQ=="
       },
-      "FluentValidation": {
-        "type": "Direct",
-        "requested": "[12.0.0, )",
-        "resolved": "12.0.0",
-        "contentHash": "8NVLxtMUXynRHJIX3Hn1ACovaqZIJASufXIIFkD0EUbcd5PmMsL1xUD5h548gCezJ5BzlITaR9CAMrGe29aWpA=="
-      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Direct",
         "requested": "[10.0.5, )",

--- a/src/Infrastructure.PostgreSql/MoneyGroup.Infrastructure.PostgreSql.csproj
+++ b/src/Infrastructure.PostgreSql/MoneyGroup.Infrastructure.PostgreSql.csproj
@@ -11,6 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
   </ItemGroup>
 

--- a/src/Infrastructure.PostgreSql/packages.lock.json
+++ b/src/Infrastructure.PostgreSql/packages.lock.json
@@ -22,6 +22,18 @@
           "Newtonsoft.Json": "13.0.3"
         }
       },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "Direct",
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "uxmFjZEAB/KbsgWFSS4lLqkEHCfXxB2x0UcbiO4e5fCRpFFeTMSx/me6009nYJLu5IKlDwO1POh++P6RilFTDw==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.5",
+          "Microsoft.Extensions.Caching.Memory": "10.0.5",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging": "10.0.5"
+        }
+      },
       "Npgsql.EntityFrameworkCore.PostgreSQL": {
         "type": "Direct",
         "requested": "[10.0.1, )",
@@ -280,7 +292,6 @@
         "dependencies": {
           "Ardalis.Specification.EntityFrameworkCore": "[9.3.1, )",
           "Microsoft.EntityFrameworkCore": "[10.0.5, )",
-          "Microsoft.EntityFrameworkCore.Relational": "[10.0.5, )",
           "MoneyGroup.Core": "[1.0.0, )"
         }
       },
@@ -316,18 +327,6 @@
           "Microsoft.EntityFrameworkCore.Abstractions": "10.0.5",
           "Microsoft.EntityFrameworkCore.Analyzers": "10.0.5",
           "Microsoft.Extensions.Caching.Memory": "10.0.5",
-          "Microsoft.Extensions.Logging": "10.0.5"
-        }
-      },
-      "Microsoft.EntityFrameworkCore.Relational": {
-        "type": "CentralTransitive",
-        "requested": "[10.0.5, )",
-        "resolved": "10.0.5",
-        "contentHash": "uxmFjZEAB/KbsgWFSS4lLqkEHCfXxB2x0UcbiO4e5fCRpFFeTMSx/me6009nYJLu5IKlDwO1POh++P6RilFTDw==",
-        "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.5",
-          "Microsoft.Extensions.Caching.Memory": "10.0.5",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
           "Microsoft.Extensions.Logging": "10.0.5"
         }
       },

--- a/src/Infrastructure.SqlServer/packages.lock.json
+++ b/src/Infrastructure.SqlServer/packages.lock.json
@@ -441,7 +441,6 @@
         "dependencies": {
           "Ardalis.Specification.EntityFrameworkCore": "[9.3.1, )",
           "Microsoft.EntityFrameworkCore": "[10.0.5, )",
-          "Microsoft.EntityFrameworkCore.Relational": "[10.0.5, )",
           "MoneyGroup.Core": "[1.0.0, )"
         }
       },

--- a/src/Infrastructure/MoneyGroup.Infrastructure.csproj
+++ b/src/Infrastructure/MoneyGroup.Infrastructure.csproj
@@ -9,7 +9,6 @@
   <ItemGroup>
     <PackageReference Include="Ardalis.Specification.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
     <PackageReference Include="Riok.Mapperly" ExcludeAssets="runtime" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Infrastructure/packages.lock.json
+++ b/src/Infrastructure/packages.lock.json
@@ -25,18 +25,6 @@
           "Microsoft.Extensions.Logging": "10.0.5"
         }
       },
-      "Microsoft.EntityFrameworkCore.Relational": {
-        "type": "Direct",
-        "requested": "[10.0.5, )",
-        "resolved": "10.0.5",
-        "contentHash": "uxmFjZEAB/KbsgWFSS4lLqkEHCfXxB2x0UcbiO4e5fCRpFFeTMSx/me6009nYJLu5IKlDwO1POh++P6RilFTDw==",
-        "dependencies": {
-          "Microsoft.EntityFrameworkCore": "10.0.5",
-          "Microsoft.Extensions.Caching.Memory": "10.0.5",
-          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
-          "Microsoft.Extensions.Logging": "10.0.5"
-        }
-      },
       "Riok.Mapperly": {
         "type": "Direct",
         "requested": "[4.2.1, )",
@@ -137,6 +125,18 @@
         "requested": "[12.0.0, )",
         "resolved": "12.0.0",
         "contentHash": "8NVLxtMUXynRHJIX3Hn1ACovaqZIJASufXIIFkD0EUbcd5PmMsL1xUD5h548gCezJ5BzlITaR9CAMrGe29aWpA=="
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "uxmFjZEAB/KbsgWFSS4lLqkEHCfXxB2x0UcbiO4e5fCRpFFeTMSx/me6009nYJLu5IKlDwO1POh++P6RilFTDw==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.5",
+          "Microsoft.Extensions.Caching.Memory": "10.0.5",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging": "10.0.5"
+        }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",

--- a/src/Postgres.Migrator/packages.lock.json
+++ b/src/Postgres.Migrator/packages.lock.json
@@ -490,7 +490,6 @@
         "dependencies": {
           "Ardalis.Specification.EntityFrameworkCore": "[9.3.1, )",
           "Microsoft.EntityFrameworkCore": "[10.0.5, )",
-          "Microsoft.EntityFrameworkCore.Relational": "[10.0.5, )",
           "MoneyGroup.Core": "[1.0.0, )"
         }
       },

--- a/src/WebApi/Endpoints/OrderPaginationRequest.cs
+++ b/src/WebApi/Endpoints/OrderPaginationRequest.cs
@@ -3,7 +3,7 @@
 using Microsoft.AspNetCore.Mvc;
 
 using MoneyGroup.Core.Models.Orders;
-using MoneyGroup.Core.Validators;
+using MoneyGroup.WebApi.Validators;
 
 namespace MoneyGroup.WebApi.Endpoints;
 

--- a/src/WebApi/Endpoints/UserPaginatedRequest.cs
+++ b/src/WebApi/Endpoints/UserPaginatedRequest.cs
@@ -3,7 +3,7 @@
 using Microsoft.AspNetCore.Mvc;
 
 using MoneyGroup.Core.Models.Users;
-using MoneyGroup.Core.Validators;
+using MoneyGroup.WebApi.Validators;
 
 namespace MoneyGroup.WebApi.Endpoints;
 

--- a/src/WebApi/MoneyGroup.WebApi.csproj
+++ b/src/WebApi/MoneyGroup.WebApi.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="FluentValidation" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design">

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -9,7 +9,6 @@ using MoneyGroup.Core.Abstractions;
 using MoneyGroup.Core.Models;
 using MoneyGroup.Core.Models.Orders;
 using MoneyGroup.Core.Services;
-using MoneyGroup.Core.Validators;
 using MoneyGroup.Infrastructure.Data;
 using MoneyGroup.Infrastructure.Mapperly;
 using MoneyGroup.Infrastructure.SqlServer;

--- a/src/WebApi/Validators/OrderDtoValidator.cs
+++ b/src/WebApi/Validators/OrderDtoValidator.cs
@@ -2,7 +2,7 @@ using FluentValidation;
 
 using MoneyGroup.Core.Models.Orders;
 
-namespace MoneyGroup.Core.Validators;
+namespace MoneyGroup.WebApi.Validators;
 
 public class OrderDtoValidator : AbstractValidator<OrderDto>
 {

--- a/src/WebApi/Validators/PaginatedOptionsValidator.cs
+++ b/src/WebApi/Validators/PaginatedOptionsValidator.cs
@@ -2,7 +2,7 @@
 
 using MoneyGroup.Core.Abstractions;
 
-namespace MoneyGroup.Core.Validators;
+namespace MoneyGroup.WebApi.Validators;
 
 public class PaginatedOptionsValidator : AbstractValidator<IPaginatedOptions>
 {

--- a/src/WebApi/Validators/ParticipantDtoValidator.cs
+++ b/src/WebApi/Validators/ParticipantDtoValidator.cs
@@ -3,7 +3,7 @@ using FluentValidation.Results;
 
 using MoneyGroup.Core.Models.Orders;
 
-namespace MoneyGroup.Core.Validators;
+namespace MoneyGroup.WebApi.Validators;
 
 public class ParticipantDtoValidator : AbstractValidator<ParticipantDto>
 {

--- a/src/WebApi/packages.lock.json
+++ b/src/WebApi/packages.lock.json
@@ -17,6 +17,12 @@
           "System.Security.Cryptography.Pkcs": "10.0.5"
         }
       },
+      "FluentValidation": {
+        "type": "Direct",
+        "requested": "[12.0.0, )",
+        "resolved": "12.0.0",
+        "contentHash": "8NVLxtMUXynRHJIX3Hn1ACovaqZIJASufXIIFkD0EUbcd5PmMsL1xUD5h548gCezJ5BzlITaR9CAMrGe29aWpA=="
+      },
       "Microsoft.AspNetCore.Authentication.JwtBearer": {
         "type": "Direct",
         "requested": "[10.0.5, )",
@@ -519,8 +525,7 @@
       "moneygroup.core": {
         "type": "Project",
         "dependencies": {
-          "Ardalis.Specification": "[9.3.1, )",
-          "FluentValidation": "[12.0.0, )"
+          "Ardalis.Specification": "[9.3.1, )"
         }
       },
       "moneygroup.infrastructure": {
@@ -567,12 +572,6 @@
           "Microsoft.EntityFrameworkCore": "9.0.8",
           "Microsoft.EntityFrameworkCore.Relational": "9.0.8"
         }
-      },
-      "FluentValidation": {
-        "type": "CentralTransitive",
-        "requested": "[12.0.0, )",
-        "resolved": "12.0.0",
-        "contentHash": "8NVLxtMUXynRHJIX3Hn1ACovaqZIJASufXIIFkD0EUbcd5PmMsL1xUD5h548gCezJ5BzlITaR9CAMrGe29aWpA=="
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "CentralTransitive",

--- a/src/WebApi/packages.lock.json
+++ b/src/WebApi/packages.lock.json
@@ -528,7 +528,6 @@
         "dependencies": {
           "Ardalis.Specification.EntityFrameworkCore": "[9.3.1, )",
           "Microsoft.EntityFrameworkCore": "[10.0.5, )",
-          "Microsoft.EntityFrameworkCore.Relational": "[10.0.5, )",
           "MoneyGroup.Core": "[1.0.0, )"
         }
       },

--- a/test/FunctionalTests/Validators/OrderDtoValidatorTest.cs
+++ b/test/FunctionalTests/Validators/OrderDtoValidatorTest.cs
@@ -1,9 +1,9 @@
 using FluentValidation.TestHelper;
 
 using MoneyGroup.Core.Models.Orders;
-using MoneyGroup.Core.Validators;
+using MoneyGroup.WebApi.Validators;
 
-namespace MoneyGroup.UnitTests.Validators;
+namespace MoneyGroup.FunctionalTests.Validators;
 
 public class OrderDtoValidatorTestFixture
 {

--- a/test/FunctionalTests/Validators/OrderPaginatedRequestValidatorTests.cs
+++ b/test/FunctionalTests/Validators/OrderPaginatedRequestValidatorTests.cs
@@ -1,6 +1,5 @@
 using FluentValidation.TestHelper;
 
-using MoneyGroup.Core.Validators;
 using MoneyGroup.WebApi.Endpoints;
 using MoneyGroup.WebApi.Validators;
 

--- a/test/FunctionalTests/Validators/ParticipantDtoValidatorTest.cs
+++ b/test/FunctionalTests/Validators/ParticipantDtoValidatorTest.cs
@@ -1,9 +1,9 @@
 using FluentValidation.TestHelper;
 
 using MoneyGroup.Core.Models.Orders;
-using MoneyGroup.Core.Validators;
+using MoneyGroup.WebApi.Validators;
 
-namespace MoneyGroup.UnitTests.Validators;
+namespace MoneyGroup.FunctionalTests.Validators;
 
 public class ParticipantDtoValidatorTest
     : IClassFixture<ParticipantDtoValidator>

--- a/test/FunctionalTests/packages.lock.json
+++ b/test/FunctionalTests/packages.lock.json
@@ -821,7 +821,6 @@
         "dependencies": {
           "Ardalis.Specification.EntityFrameworkCore": "[9.3.1, )",
           "Microsoft.EntityFrameworkCore": "[10.0.5, )",
-          "Microsoft.EntityFrameworkCore.Relational": "[10.0.5, )",
           "MoneyGroup.Core": "[1.0.0, )"
         }
       },

--- a/test/FunctionalTests/packages.lock.json
+++ b/test/FunctionalTests/packages.lock.json
@@ -812,7 +812,6 @@
         "type": "Project",
         "dependencies": {
           "Ardalis.Specification": "[9.3.1, )",
-          "FluentValidation": "[12.0.0, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.5, )"
         }
       },
@@ -848,6 +847,7 @@
         "type": "Project",
         "dependencies": {
           "Aspire.Microsoft.EntityFrameworkCore.SqlServer": "[13.2.1, )",
+          "FluentValidation": "[12.0.0, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.5, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.5, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.0.5, )",

--- a/test/IntegrationTests/packages.lock.json
+++ b/test/IntegrationTests/packages.lock.json
@@ -685,13 +685,13 @@
         "dependencies": {
           "Ardalis.Specification.EntityFrameworkCore": "[9.3.1, )",
           "Microsoft.EntityFrameworkCore": "[10.0.5, )",
-          "Microsoft.EntityFrameworkCore.Relational": "[10.0.5, )",
           "MoneyGroup.Core": "[1.0.0, )"
         }
       },
       "moneygroup.infrastructure.postgresql": {
         "type": "Project",
         "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.5, )",
           "MoneyGroup.Infrastructure": "[1.0.0, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.1, )"
         }


### PR DESCRIPTION
#### PR Classification
Code cleanup and project structure refactor to align with Clean Architecture boundaries.

#### PR Summary
This PR moves all FluentValidation dependencies and validator classes from the Core project to the WebApi project, and relocates the EntityFrameworkCore.Relational package from Infrastructure to Infrastructure.PostgreSql. It also updates namespaces and references accordingly.
- MoneyGroup.Core: Removed FluentValidation package and moved validator classes out.
- MoneyGroup.WebApi: Added FluentValidation package and relocated all validator classes here, updating namespaces and using statements.
- MoneyGroup.Infrastructure and MoneyGroup.Infrastructure.PostgreSql: Moved Microsoft.EntityFrameworkCore.Relational package reference to the correct project.
- Test files: Updated namespaces to match new validator locations.
- packages.lock.json: Updated to reflect all dependency and reference changes.
