### PR TITLE
refactor: move ClientApp project into /src/ solution folder

### DIFF
--- a/MoneyGroup.slnx
+++ b/MoneyGroup.slnx
@@ -13,6 +13,9 @@
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/AppHost/MoneyGroup.AppHost.csproj" />
+    <Project Path="src/ClientApp/MoneyGroup.ClientApp.esproj">
+      <Platform Project="AnyCPU" />
+    </Project>
     <Project Path="src/Core/MoneyGroup.Core.csproj" />
     <Project Path="src/Infrastructure.PostgreSql/MoneyGroup.Infrastructure.PostgreSql.csproj" />
     <Project Path="src/Infrastructure.SqlServer/MoneyGroup.Infrastructure.SqlServer.csproj" />
@@ -20,11 +23,6 @@
     <Project Path="src/Postgres.Migrator/MoneyGroup.Postgres.Migrator.csproj" />
     <Project Path="src/ServiceDefaults/MoneyGroup.ServiceDefaults.csproj" />
     <Project Path="src/WebApi/MoneyGroup.WebApi.csproj" />
-  </Folder>
-  <Folder Name="/src/ClientApp/">
-    <Project Path="src/ClientApp/MoneyGroup.ClientApp.esproj">
-      <Platform Project="AnyCPU" />
-    </Project>
   </Folder>
   <Folder Name="/test/">
     <Project Path="test/AppHost.Tests/AppHost.Tests.csproj" />


### PR DESCRIPTION
## Summary
Moves the `MoneyGroup.ClientApp` project from its own dedicated solution folder (`/src/ClientApp/`) into the main `/src/` solution folder, making it consistent with all other source projects.

## Changes
- `MoneyGroup.slnx`: Removed the `/src/ClientApp/` solution folder and re-added the project directly under `/src/`