### PR TITLE
security: harden Azure Static Web Apps workflow

### DIFF
--- a/.github/workflows/azure-static-web-apps-mango-forest-03b3e8000.yml
+++ b/.github/workflows/azure-static-web-apps-mango-forest-03b3e8000.yml
@@ -5,12 +5,10 @@ on:
     branches: ["main"]
     paths:
       - src/ClientApp/**
-      - .github/workflows/azure-static-web-apps-mango-forest-03b3e8000.yml
   pull_request:
     branches: ["main"]
     paths:
       - src/ClientApp/**
-      - .github/workflows/azure-static-web-apps-mango-forest-03b3e8000.yml
 jobs:
   build_and_deploy_job:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
@@ -30,7 +28,7 @@ jobs:
           cache-dependency-path: src/ClientApp/package-lock.json
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
         working-directory: src/ClientApp
 
       - name: Build client app
@@ -39,7 +37,7 @@ jobs:
 
       - name: Build And Deploy
         id: builddeploy
-        uses: Azure/static-web-apps-deploy@v1
+        uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_MANGO_FOREST_03B3E8000 }}
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
@@ -60,7 +58,7 @@ jobs:
     steps:
       - name: Close Pull Request
         id: closepullrequest
-        uses: Azure/static-web-apps-deploy@v1
+        uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_MANGO_FOREST_03B3E8000 }}
           action: "close"


### PR DESCRIPTION
## Summary
Hardens the Azure Static Web Apps CI workflow against supply chain attacks.

## Changes
- `npm ci` → `npm ci --ignore-scripts`: prevents lifecycle scripts (e.g. `postinstall`) from executing during dependency installation
- Pin `Azure/static-web-apps-deploy` action to an exact commit SHA instead of the mutable `v1` tag, protecting against tag hijacking