### PR TITLE
Enable locked mode for .NET tool restore in workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -49,7 +49,7 @@ jobs:
           dotnet sonarscanner begin /k:"vancodocton_MoneyGroup" /o:"vancodocton" /d:sonar.token="$env:SONAR_TOKEN" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.scanner.skipJreProvisioning=true
 
       - name: Restore
-        run: dotnet restore ${{ env.Solution }}
+        run: dotnet restore ${{ env.Solution }}  --locked-mode
 
       - name: Build
         run: dotnet build ${{ env.Solution }} --no-restore --configuration Release


### PR DESCRIPTION
Update the .NET tool restore command in the workflow to use locked mode, ensuring consistent tool versions during restoration.