### PR TITLE
Update .NET SDK rollForward policy and clean up lock files

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "10.0.202",
-    "rollForward": "latestMinor"
+    "rollForward": "latestPatch"
   },
   "test": {
     "runner": "Microsoft.Testing.Platform"

--- a/src/Infrastructure.PostgreSql/packages.lock.json
+++ b/src/Infrastructure.PostgreSql/packages.lock.json
@@ -283,7 +283,6 @@
         "type": "Project",
         "dependencies": {
           "Ardalis.Specification": "[9.3.1, )",
-          "FluentValidation": "[12.0.0, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.5, )"
         }
       },
@@ -311,12 +310,6 @@
           "Microsoft.EntityFrameworkCore": "9.0.8",
           "Microsoft.EntityFrameworkCore.Relational": "9.0.8"
         }
-      },
-      "FluentValidation": {
-        "type": "CentralTransitive",
-        "requested": "[12.0.0, )",
-        "resolved": "12.0.0",
-        "contentHash": "8NVLxtMUXynRHJIX3Hn1ACovaqZIJASufXIIFkD0EUbcd5PmMsL1xUD5h548gCezJ5BzlITaR9CAMrGe29aWpA=="
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "CentralTransitive",

--- a/src/Infrastructure.SqlServer/packages.lock.json
+++ b/src/Infrastructure.SqlServer/packages.lock.json
@@ -432,7 +432,6 @@
         "type": "Project",
         "dependencies": {
           "Ardalis.Specification": "[9.3.1, )",
-          "FluentValidation": "[12.0.0, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.5, )"
         }
       },
@@ -460,12 +459,6 @@
           "Microsoft.EntityFrameworkCore": "9.0.8",
           "Microsoft.EntityFrameworkCore.Relational": "9.0.8"
         }
-      },
-      "FluentValidation": {
-        "type": "CentralTransitive",
-        "requested": "[12.0.0, )",
-        "resolved": "12.0.0",
-        "contentHash": "8NVLxtMUXynRHJIX3Hn1ACovaqZIJASufXIIFkD0EUbcd5PmMsL1xUD5h548gCezJ5BzlITaR9CAMrGe29aWpA=="
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "CentralTransitive",

--- a/src/Infrastructure/packages.lock.json
+++ b/src/Infrastructure/packages.lock.json
@@ -110,7 +110,6 @@
         "type": "Project",
         "dependencies": {
           "Ardalis.Specification": "[9.3.1, )",
-          "FluentValidation": "[12.0.0, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.5, )"
         }
       },
@@ -119,12 +118,6 @@
         "requested": "[9.3.1, )",
         "resolved": "9.3.1",
         "contentHash": "GWrE6BA0smWFLbN+XPU2l5rDF9Uzelfbb3w35jJ0CGIat+p1ChbtLcbkvYRMEculBHOAo12omwAAOm3VFWkoJQ=="
-      },
-      "FluentValidation": {
-        "type": "CentralTransitive",
-        "requested": "[12.0.0, )",
-        "resolved": "12.0.0",
-        "contentHash": "8NVLxtMUXynRHJIX3Hn1ACovaqZIJASufXIIFkD0EUbcd5PmMsL1xUD5h548gCezJ5BzlITaR9CAMrGe29aWpA=="
       },
       "Microsoft.EntityFrameworkCore.Relational": {
         "type": "CentralTransitive",

--- a/src/Postgres.Migrator/packages.lock.json
+++ b/src/Postgres.Migrator/packages.lock.json
@@ -481,7 +481,6 @@
         "type": "Project",
         "dependencies": {
           "Ardalis.Specification": "[9.3.1, )",
-          "FluentValidation": "[12.0.0, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.5, )"
         }
       },
@@ -516,12 +515,6 @@
           "Microsoft.EntityFrameworkCore": "9.0.8",
           "Microsoft.EntityFrameworkCore.Relational": "9.0.8"
         }
-      },
-      "FluentValidation": {
-        "type": "CentralTransitive",
-        "requested": "[12.0.0, )",
-        "resolved": "12.0.0",
-        "contentHash": "8NVLxtMUXynRHJIX3Hn1ACovaqZIJASufXIIFkD0EUbcd5PmMsL1xUD5h548gCezJ5BzlITaR9CAMrGe29aWpA=="
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "CentralTransitive",

--- a/test/IntegrationTests/packages.lock.json
+++ b/test/IntegrationTests/packages.lock.json
@@ -676,7 +676,6 @@
         "type": "Project",
         "dependencies": {
           "Ardalis.Specification": "[9.3.1, )",
-          "FluentValidation": "[12.0.0, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.5, )"
         }
       },
@@ -719,12 +718,6 @@
           "Microsoft.EntityFrameworkCore": "9.0.8",
           "Microsoft.EntityFrameworkCore.Relational": "9.0.8"
         }
-      },
-      "FluentValidation": {
-        "type": "CentralTransitive",
-        "requested": "[12.0.0, )",
-        "resolved": "12.0.0",
-        "contentHash": "8NVLxtMUXynRHJIX3Hn1ACovaqZIJASufXIIFkD0EUbcd5PmMsL1xUD5h548gCezJ5BzlITaR9CAMrGe29aWpA=="
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "CentralTransitive",

--- a/test/UnitTests/packages.lock.json
+++ b/test/UnitTests/packages.lock.json
@@ -167,7 +167,6 @@
         "type": "Project",
         "dependencies": {
           "Ardalis.Specification": "[9.3.1, )",
-          "FluentValidation": "[12.0.0, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.5, )"
         }
       },
@@ -176,12 +175,6 @@
         "requested": "[9.3.1, )",
         "resolved": "9.3.1",
         "contentHash": "GWrE6BA0smWFLbN+XPU2l5rDF9Uzelfbb3w35jJ0CGIat+p1ChbtLcbkvYRMEculBHOAo12omwAAOm3VFWkoJQ=="
-      },
-      "FluentValidation": {
-        "type": "CentralTransitive",
-        "requested": "[12.0.0, )",
-        "resolved": "12.0.0",
-        "contentHash": "8NVLxtMUXynRHJIX3Hn1ACovaqZIJASufXIIFkD0EUbcd5PmMsL1xUD5h548gCezJ5BzlITaR9CAMrGe29aWpA=="
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",


### PR DESCRIPTION
Change the rollForward policy in global.json to latestPatch and remove outdated FluentValidation dependencies from various lock files. This ensures compatibility with the latest patches and reduces unnecessary package references.