### PR TITLE
chore: update Aspire EF Core SQL Server to 13.2.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="Aspire.Hosting.JavaScript" Version="13.2.2" />
     <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.2.2" />
     <PackageVersion Include="Aspire.Hosting.Testing" Version="13.2.2" />
-    <PackageVersion Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.2.1" />
+    <PackageVersion Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.2.2" />
     <PackageVersion Include="Duende.IdentityModel" Version="7.1.0" />
     <PackageVersion Include="FluentValidation" Version="12.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />

--- a/src/WebApi/packages.lock.json
+++ b/src/WebApi/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0": {
       "Aspire.Microsoft.EntityFrameworkCore.SqlServer": {
         "type": "Direct",
-        "requested": "[13.2.1, )",
-        "resolved": "13.2.1",
-        "contentHash": "mdjcUfNhFRwZ0r4YGmbBjzek+K0z1sOUo+ePl1UT+0VlwLuARjMAEC61BfB+gHrxJtN1nsbd+jpjC+sUXQIcFg==",
+        "requested": "[13.2.2, )",
+        "resolved": "13.2.2",
+        "contentHash": "mJ4WM7fsXyhS6U9+7CVlWqM2sQISRKBnazPRUKxoPRKt/yD80erQFnKY2eRglPVsZQ5RZzYHFzNGIZdpNQvhRA==",
         "dependencies": {
           "Azure.Core": "1.51.1",
           "Azure.Identity": "1.18.0",

--- a/test/FunctionalTests/packages.lock.json
+++ b/test/FunctionalTests/packages.lock.json
@@ -846,7 +846,7 @@
       "moneygroup.webapi": {
         "type": "Project",
         "dependencies": {
-          "Aspire.Microsoft.EntityFrameworkCore.SqlServer": "[13.2.1, )",
+          "Aspire.Microsoft.EntityFrameworkCore.SqlServer": "[13.2.2, )",
           "FluentValidation": "[12.0.0, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.5, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.5, )",
@@ -879,9 +879,9 @@
       },
       "Aspire.Microsoft.EntityFrameworkCore.SqlServer": {
         "type": "CentralTransitive",
-        "requested": "[13.2.1, )",
-        "resolved": "13.2.1",
-        "contentHash": "mdjcUfNhFRwZ0r4YGmbBjzek+K0z1sOUo+ePl1UT+0VlwLuARjMAEC61BfB+gHrxJtN1nsbd+jpjC+sUXQIcFg==",
+        "requested": "[13.2.2, )",
+        "resolved": "13.2.2",
+        "contentHash": "mJ4WM7fsXyhS6U9+7CVlWqM2sQISRKBnazPRUKxoPRKt/yD80erQFnKY2eRglPVsZQ5RZzYHFzNGIZdpNQvhRA==",
         "dependencies": {
           "Azure.Core": "1.51.1",
           "Azure.Identity": "1.18.0",


### PR DESCRIPTION
## Summary
- update Aspire.Microsoft.EntityFrameworkCore.SqlServer from 13.2.1 to 13.2.2
- refresh dependent lock files in WebApi and FunctionalTests

## Validation
- dotnet build ✅
- Functional tests: 28 passed, 20 failed
- Failures are pre-existing environment/configuration issues in 	est/FunctionalTests/Fixture/WebApiFactory.cs due missing Test:Google:RefreshToken (Parameter is required (Parameter 'refresh_token'))
