### PR TITLE
fix: exclude NU1902 from TreatWarningsAsErrors to unblock CI

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <Deterministic>true</Deterministic>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1902</WarningsNotAsErrors>
     <!-- Enable Microsoft.Testing.Platform runner globally for test projects -->
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>


### PR DESCRIPTION
## Problem

\TreatWarningsAsErrors=true\ promotes NuGet audit warnings to errors. The \OpenTelemetry.Exporter.OpenTelemetryProtocol\ and \OpenTelemetry.Api\ packages at version \1.15.1\ have known moderate-severity vulnerabilities, triggering \NU1902\ warnings that break the CI pipeline.

## Fix

Add \NU1902\ to \WarningsNotAsErrors\ so it stays a warning without blocking builds.

\\\xml
<WarningsNotAsErrors>\;NU1902</WarningsNotAsErrors>
\\\

## Follow-up

The OpenTelemetry packages should be updated to a patched version in a separate PR to fully resolve the underlying vulnerabilities.