### PR TITLE
feat: integrate with dotnet user-jwt for local development

### DIFF
--- a/src/WebApi/appsettings.Development.json
+++ b/src/WebApi/appsettings.Development.json
@@ -6,6 +6,16 @@
     }
   },
   "Authentication": {
-    "Schemes": {}
+    "Schemes": {
+      "Bearer": {
+        "ValidAudiences": [
+          "http://localhost:65503",
+          "https://localhost:44313",
+          "http://localhost:5200",
+          "https://localhost:7248"
+        ],
+        "ValidIssuer": "dotnet-user-jwts"
+      }
+    }
   }
 }

--- a/src/WebApi/appsettings.json
+++ b/src/WebApi/appsettings.json
@@ -9,8 +9,9 @@
     "Schemes": {
       "Bearer": {
         "MetadataAddress": "https://accounts.google.com/.well-known/openid-configuration",
-        "ValidAudiences": [
-          "767018411802-sqvqnsa0ggitqvn6kkebsa7qbmhlinp4.apps.googleusercontent.com"
+        "ValidAudience": "767018411802-sqvqnsa0ggitqvn6kkebsa7qbmhlinp4.apps.googleusercontent.com",
+        "ValidIssuers": [
+          "https://accounts.google.com"
         ]
       }
     }


### PR DESCRIPTION
This pull request updates authentication configuration in both the development and production settings to improve JWT validation and issuer/audience handling. The main changes clarify and expand the accepted audiences and issuers for bearer authentication, ensuring better compatibility with local development and external identity providers.

**Authentication configuration improvements:**

* In `appsettings.Development.json`, added a `Bearer` scheme with multiple `ValidAudiences` for local development URLs and specified `ValidIssuer` as `dotnet-user-jwts`.
* In `appsettings.json`, changed `ValidAudiences` to `ValidAudience` for the Google client ID, and added `ValidIssuers` to explicitly list `https://accounts.google.com` as an accepted issuer.