### PR TITLE
Refactor CI to separate dotnet format into distinct job

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -10,6 +10,24 @@ env:
   Solution: MoneyGroup.slnx
 
 jobs:
+  verify-format:
+    name: Verify Code Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          cache: true
+          cache-dependency-path: |
+            **/packages.lock.json
+            **/dotnet-tools.json
+
+      - name: Verify Format
+        run: dotnet format ${{ env.Solution }} --no-restore --verify-no-changes -v diag --severity info
+
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -53,9 +71,6 @@ jobs:
 
       - name: Build
         run: dotnet build ${{ env.Solution }} --no-restore --configuration Release
-
-      - name: Verify Format
-        run: dotnet format ${{ env.Solution }} --no-restore --verify-no-changes -v diag --severity info
 
       - name: Test
         shell: pwsh

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -26,7 +26,7 @@ jobs:
             **/dotnet-tools.json
 
       - name: Verify Format
-        run: dotnet format ${{ env.Solution }} --no-restore --verify-no-changes -v diag --severity info
+        run: dotnet format ${{ env.Solution }} --verify-no-changes -v diag --severity info
 
   build:
     name: Build


### PR DESCRIPTION
Separate the verification of code format into its own job within the CI pipeline, enhancing clarity and maintainability. This change removes the format verification from the build job.