### PR TITLE
ci: use Java 21 for SonarQube scanner

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -59,6 +59,12 @@ jobs:
       - name: Restore .NET tools
         run: dotnet tool restore
 
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+
       - name: Begin Analyze
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary
- Sonar's dotnet-sonarscanner requires Java 21+; add `actions/setup-java@v5` (Temurin 21) before the SonarQube begin/end steps.
- GitHub-hosted runners already have Temurin 21 in the tool cache (`JAVA_HOME_21_X64`), so this resolves from cache rather than downloading a new JDK.

## Test plan
- [ ] CI run passes and SonarQube analysis completes successfully