### PR TITLE
chore: allow SDK roll-forward to latest minor

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "10.0.302",
-    "rollForward": "latestPatch"
+    "rollForward": "latestMinor"
   },
   "test": {
     "runner": "Microsoft.Testing.Platform"


### PR DESCRIPTION
## Summary

`global.json` pins the SDK to `10.0.302` with `rollForward: "latestPatch"`, which only resolves within the `10.0.3xx` feature band. Any machine or CI image carrying a newer feature band — e.g. `10.0.400` — fails to satisfy `global.json` and cannot build the repo.

This widens the policy to `latestMinor`, so any `10.x` SDK at or above the pinned version is accepted.

```diff
   "sdk": {
     "version": "10.0.302",
-    "rollForward": "latestPatch"
+    "rollForward": "latestMinor"
   },
```

## Verification

Local machine has `6.0.428`, `8.0.424`, `10.0.400` installed.

- `dotnet --version` → `10.0.400` (previously failed to resolve)
- `dotnet build` → Build succeeded, 0 Warning(s), 0 Error(s)

## Note

`latestFeature` would be the narrower fix — it also reaches `10.0.400` while staying within `10.0.x`. `latestMinor` was chosen as the more permissive option; happy to tighten it if the stricter bound is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)