### PR TITLE
chore(ci): SHA-pin third-party actions and untrack cosign version pin

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -70,7 +70,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.37.6
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -93,6 +93,6 @@ jobs:
           dotnet build --configuration Release MoneyGroup.slnx
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.37.6
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,11 +42,13 @@ jobs:
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
+      # No cosign-release input on purpose: the cosign binary version is then
+      # fixed by the SHA-pinned installer below (v4.1.2 installs cosign v3.0.6),
+      # so Dependabot's installer bumps keep it current. An explicit
+      # cosign-release pin is invisible to Dependabot and goes stale silently.
       - name: Install cosign
         if: ${{ inputs.is-cd }}
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 #v4.1.2
-        with:
-          cosign-release: "v2.2.4"
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache
@@ -111,7 +113,7 @@ jobs:
       contents: read
     steps:
       - name: Log in to Azure
-        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # 3.0.1
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -106,7 +106,7 @@ jobs:
             coverage.xml
 
       - name: Upload TestResults to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: vancodocton/MoneyGroup

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Detect changed paths
         id: filter
-        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d #v4.0.3
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         with:
           filters: |
             backend:


### PR DESCRIPTION
## Policy

`actions/*` stay on version tags (first-party, trusted). Every other action is
pinned to a full commit SHA with a trailing `# vX.Y.Z` comment.

## Changes

| Action | Before | After |
| --- | --- | --- |
| `github/codeql-action/init` + `/analyze` | `@v4.37.6` | `@5595ccaf` `# v4.37.6` |
| `codecov/codecov-action` | `@v7` (moving major tag) | `@fb8b3582` `# v7.0.0` |
| `sigstore/cosign-installer` | `#v4.1.2` | `# v4.1.2` (comment style) |
| `azure/login` | `# 3.0.1` | `# v3.0.1` (comment style) |
| `dorny/paths-filter` | `#v4.0.3` | `# v4.0.3` (comment style) |

SHAs were dereferenced from the annotated tags via the GitHub API and verified
to resolve back. CodeQL stays on the version it was already running, so no
behavior change there.

## cosign version pin

Dropped the explicit `cosign-release: "v2.2.4"` input. That pinned the cosign
*binary* to a version Dependabot cannot see and had therefore never updated.
Without the input, the version is fixed by the SHA-pinned installer
(`v4.1.2` installs cosign `v3.0.6`) and moves forward whenever Dependabot bumps
the installer — turning an untracked pin into a tracked one.

⚠️ This raises cosign from `v2.2.4` to `v3.0.6`. The `cosign sign --yes {}@$DIGEST`
invocation is unchanged and keyless Fulcio/Rekor signing works the same on 3.x,
but cosign 3 changed the default signature bundle format. Nothing in this repo
verifies signatures, so CI is unaffected; anything downstream running
`cosign verify` on these images needs cosign 3.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
