### PR TITLE
fix(ci): gate deploys on tests, repair dead path filters, deploy by digest

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,7 +15,7 @@ on:
   push:
     branches: ["main", "dev"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "dev"]
   schedule:
     - cron: "43 0 * * 4"
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,16 @@ on:
       is-cd:
         type: boolean
         required: false
-        description: Whether to run the deployment job
+        description: Whether to push and sign the image (i.e. not a PR validation build)
+        default: false
+      do-deploy:
+        type: boolean
+        required: false
+        description: >-
+          Whether to deploy the built image. Separate from is-cd so that dev and
+          tag pushes still build, push and sign an image without deploying it:
+          there is a single Container App, so every ref that deploys overwrites
+          the previous one.
         default: false
       environment:
         type: string
@@ -29,6 +38,11 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      # Immutable digest of the image produced (and signed) by this run, so the
+      # deploy job ships exactly what was built instead of re-resolving a
+      # mutable tag that a concurrent run could have moved.
+      digest: ${{ steps.build-and-push.outputs.digest }}
     permissions:
       contents: read
       packages: write
@@ -106,7 +120,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build
-    if: ${{ inputs.is-cd }}
+    if: ${{ inputs.is-cd && inputs.do-deploy }}
     environment: ${{ inputs.environment }}
     permissions:
       id-token: write
@@ -119,11 +133,26 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # Build the immutable image reference from the digest the build job
+      # produced and signed. env.IMAGE_NAME is github.repository, which is
+      # mixed case (vancodocton/MoneyGroup); container registries reject
+      # non-lowercase paths, so lowercase it explicitly here. Inputs are passed
+      # through an intermediate env block rather than interpolated into `run:`.
+      # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+      - name: Resolve image reference
+        id: image
+        env:
+          REGISTRY_HOST: ${{ env.REGISTRY }}
+          IMAGE_REPOSITORY: ${{ env.IMAGE_NAME }}
+          DIGEST: ${{ needs.build.outputs.digest }}
+        run: |
+          if [[ -z "${DIGEST}" ]]; then
+            echo "::error::build job produced no image digest — refusing to deploy." \
+                 "The image is only pushed when is-cd is true; deploying without a" \
+                 "digest would resolve to an empty reference."
+            exit 1
+          fi
+          echo "ref=${REGISTRY_HOST,,}/${IMAGE_REPOSITORY,,}@${DIGEST}" >> "$GITHUB_OUTPUT"
 
       - name: Deploy Azure Container App
         uses: azure/container-apps-deploy-action@8dff69dac3367c32ceb2690d8f13adbeab462703 # v2
@@ -131,4 +160,4 @@ jobs:
           containerAppName: ${{ secrets.AZURE_CONTAINER_APP_NAME }}
           resourceGroup: ${{ secrets.AZURE_RESOURCE_GROUP }}
           registryUrl: ${{ env.REGISTRY }}
-          imageToDeploy: ${{ steps.meta.outputs.tags }}
+          imageToDeploy: ${{ steps.image.outputs.ref }}

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -3,8 +3,12 @@ on:
     branches: ["main", "dev"]
     tags: ["v*.*.*"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "dev"]
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   changes:
@@ -50,17 +54,18 @@ jobs:
   backend:
     uses: ./.github/workflows/dotnet.yml
     needs: changes
-    if: ${{ needs.changes.outputs.backend }}
+    if: ${{ needs.changes.outputs.backend == 'true' }}
     secrets: inherit
     permissions:
       contents: read
 
   deploy:
     uses: ./.github/workflows/docker.yml
-    needs: changes
-    if: ${{ needs.changes.outputs.deploy }}
+    needs: [changes, backend]
+    if: ${{ !cancelled() && needs.changes.outputs.deploy == 'true' && needs.backend.result != 'failure' }}
     with:
       is-cd: ${{ github.event_name != 'pull_request' }}
+      do-deploy: ${{ github.ref == 'refs/heads/main' }}
       environment: Development
     secrets: inherit
     permissions:


### PR DESCRIPTION
Fixes the four **critical** items from the pipeline review. Two of them are confirmed by evidence in real workflow runs, not just by reading the YAML.

## What was broken

### 1. Deploy was not gated on tests
`gate.yml`'s `deploy` job had `needs: changes` only. Image build → GHCR push → cosign sign → Azure Container Apps deploy all ran **in parallel** with `backend`, and the `gate` job reported failure only *after* the deploy had already landed.

> **Evidence:** run `30964178666` — `deploy/deploy` completed at `00:45:44`, `backend/Build` ran until `00:46:19`.

`deploy` now needs `backend`. The condition leads with `!cancelled()` on purpose: a job's `if:` is implicitly ANDed with `success()` unless it contains a status function, so without it a **skipped** backend would silently skip deploy too — which only became reachable once #2 was fixed.

### 2. All path filtering was dead code
`if: ${{ needs.changes.outputs.backend }}` reads a job output. Job outputs are always **strings**, and GitHub casts any non-empty string to `true` — including the literal `"false"`. Every job always ran.

> **Evidence:** run `30329379872`, a ClientApp-only PR, logged `Filter backend = false` and then ran `backend/Build`, `backend/Verify Code Format` and `deploy/build` anyway.

Now compared explicitly against `'true'`.

### 3. Deploy shipped a mutable tag, not the digest it built and signed
The `deploy` job re-ran `metadata-action` and deployed `:main`. A concurrent push to `main` could move that tag between jobs and deploy **another run's image**, which also made the cosign signature ceremonial — the signed digest was never guaranteed to be what shipped. It additionally only worked by accident: `meta.outputs.tags` is newline-delimited and a `v*.*.*` tag push yields several tags.

`build` now exports the digest; `deploy` consumes `ghcr.io/…@sha256:…`.

This surfaced a hidden dependency worth calling out: `metadata-action` was silently lowercasing the mixed-case `github.repository` (`vancodocton/MoneyGroup`). Registries reject non-lowercase paths, so the digest reference lowercases it explicitly — otherwise removing that step would have broken the deploy.

### 4. `dev`, `main` and `v*.*.*` tags all deployed to the same Container App
No concurrency group anywhere, so they raced and overwrote each other. Deploys are now restricted to `main` via a new `do-deploy` input, kept **separate** from `is-cd` so `dev` and tag pushes still build, push and sign an image without deploying it. A concurrency group cancels superseded PR runs and serializes same-ref pushes.

PRs targeting `dev` also received **no CI at all** — `gate.yml` and `codeql.yml` both triggered on `main` only. They now cover `dev`.

## Not addressed — needs infrastructure, not a workflow change

**There is still no production CD path.** Every `AZURE_*` secret lives on a single `Development` environment and there is exactly one Container App. Restricting deploys to `main` stops the overwrite races, but a genuine prod path needs an Azure Container App and a `Production` environment provisioned first. Any workflow change before that would be cosmetic.

## Tradeoffs you should agree with before merging

- **PR feedback gets slower.** Because `deploy` now needs `backend`, the Docker validation build no longer overlaps with the .NET build — it runs after it. Correctness over latency, but it is a real change to PR wall-time. (`cache-from: type=gha` softens it.)
- **`workflow_dispatch` from `main` will deploy**, since `github.ref` is `refs/heads/main` and `is-cd` is true. Consistent with "only main deploys", but worth confirming that is what you want from a manual run.
- **Superseded PR runs will show a red `gate`.** With `cancel-in-progress`, a cancelled `backend` trips the existing `!= "success"` guard. Pre-existing behavior, not a regression — it only affects runs already replaced by a newer one.

## Verification

All five workflow files parse. Parsed values asserted directly (needs lists, `if` strings, `with` block, concurrency, branch lists) rather than relying on a non-crash. The `gate` job's bash was traced through four cases — backend succeeds, backend skipped via the `.dockerignore`-only path, deploy skipped, backend fails — and reaches the right verdict in each; on a backend failure, deploy is skipped and no GHCR push, cosign or Azure deploy occurs.

Not verified: no live workflow run, and no lint against the Actions schema (`actionlint` unavailable). `azure/container-apps-deploy-action` passing a digest-pinned `imageToDeploy` to `az containerapp update --image` is reasoned, not observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017S5gAqvK97ZVS5cavyAT3W
