### PR TITLE
fix(ci): replace `secrets: inherit` with least-privilege secret passing

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -5,6 +5,13 @@ permissions:
 
 on:
   workflow_call:
+    secrets:
+      SONAR_TOKEN:
+        description: SonarQube Cloud analysis token, used by the begin/end scanner steps.
+        required: false
+      CODECOV_TOKEN:
+        description: Codecov upload token, used to publish the merged coverage report.
+        required: false
 
 env:
   Solution: MoneyGroup.slnx

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -55,7 +55,11 @@ jobs:
     uses: ./.github/workflows/dotnet.yml
     needs: changes
     if: ${{ needs.changes.outputs.backend == 'true' }}
-    secrets: inherit
+    # Forward only the repository secrets dotnet.yml actually reads, instead of
+    # handing it every repository secret via `secrets: inherit`.
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     permissions:
       contents: read
 
@@ -67,7 +71,13 @@ jobs:
       is-cd: ${{ github.event_name != 'pull_request' }}
       do-deploy: ${{ github.ref == 'refs/heads/main' }}
       environment: Development
-    secrets: inherit
+    # No `secrets:` block on purpose. docker.yml needs no caller-supplied secrets:
+    # its build job uses the automatic secrets.GITHUB_TOKEN (granted to called
+    # workflows without being passed, and undeclarable since the GITHUB_ prefix is
+    # reserved), and its deploy job reads the AZURE_* values as environment secrets
+    # of the `Development` environment it declares itself. Those environment secrets
+    # do not exist at this caller's scope, so forwarding them here would pass empty
+    # strings and break the deploy.
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Backlog item **#5**. Both reusable workflows were called with `secrets: inherit`, handing each of them every repository secret regardless of need — `dotnet.yml` received secrets it has no use for, and `docker.yml` received `SONAR_TOKEN`, `CODECOV_TOKEN` and the `TEST__GOOGLE__*` values it never reads.

## Changes

**`dotnet.yml`** declares the two repository secrets it actually consumes; `gate.yml` forwards exactly those two.

Both are `required: false` rather than `true`. Fork PRs already receive empty values for repository secrets, and `required: false` keeps that failure mode no worse than it is today — fixing fork PRs properly is backlog #16 and is not attempted here.

**`docker.yml` is unchanged, and gets no `secrets:` block at all**, because it needs none:

- Its build job uses `secrets.GITHUB_TOKEN`, which is granted to called workflows automatically and cannot be declared regardless — the `GITHUB_` prefix is reserved.
- Its deploy job reads the `AZURE_*` values as **environment** secrets of the `Development` environment that the job declares itself.

## Why removing `inherit` from the deploy call is safe

This is the load-bearing claim, so the reasoning is empirical rather than a doc reading:

1. Repository-level secrets are *exactly* `CODECOV_TOKEN`, `SONAR_TOKEN`, `TEST__GOOGLE__CLIENTID/CLIENTSECRET/REFRESHTOKEN`.
2. All six `AZURE_*` secrets exist **only** on the `Development` environment.
3. `gate.yml`'s `deploy` job declares no `environment:`, so those values were never in scope at the caller.
4. Therefore `secrets: inherit` *cannot* have been the mechanism supplying them — yet the deploy demonstrably works (run `31710952017`, `az containerapp update` executed successfully).
5. They already resolve from `docker.yml`'s own `environment:` declaration, which this PR does not touch.

The docs agree, and add that the reverse would actively break things — [Reuse workflows](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows):

> Environment secrets cannot be passed from the caller workflow as `on.workflow_call` does not support the `environment` keyword.

So forwarding `AZURE_*` from `gate.yml` would not merely be redundant — it would pass empty strings and break the deploy. That is the trap this PR deliberately avoids.

One consequence worth knowing for future edits: `secrets: inherit` is exempt from the rule that passing an undeclared secret is a hard error. Now that it is gone, adding any `secrets:` key to the `deploy` call without a matching declaration in `docker.yml` will fail the workflow outright rather than silently yielding an empty string.

## What CI here can and cannot prove

**Can:** that `backend` still gets working Sonar and Codecov tokens, and that `deploy / build` still builds. That is genuine coverage of the `dotnet.yml` change.

**Cannot:** `deploy / deploy` is gated on `is-cd && do-deploy`, and `do-deploy` is `github.ref == 'refs/heads/main'`. **A PR never satisfies it.** A green check here is *not* evidence that the Azure credentials still resolve — the first execution of that path is the post-merge push to `main`. The safety argument is the static/empirical one above; the first `main` run is still worth watching.

## Incidental finding

`AZURE_LOCATION` is set on the `Development` environment but read by no workflow. Harmless, but dead — worth removing when convenient.

## Verification

All five workflow files parse. Parsed values asserted directly: `dotnet.yml` declares exactly `{SONAR_TOKEN, CODECOV_TOKEN}`; `docker.yml`'s `workflow_call` has only an `inputs` key; `gate.backend.secrets` maps exactly those two; `gate.deploy` has no `secrets` key. No `secrets: inherit` survives anywhere (the sole remaining occurrence of the word is inside an explanatory comment). Every `secrets.X` reference in each called workflow is satisfied by exactly one mechanism, and nothing is forwarded that the callee does not declare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017S5gAqvK97ZVS5cavyAT3W
