### PR TITLE
fix(ci): restore `secrets: inherit` on the deploy call

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -71,13 +71,22 @@ jobs:
       is-cd: ${{ github.event_name != 'pull_request' }}
       do-deploy: ${{ github.ref == 'refs/heads/main' }}
       environment: Development
-    # No `secrets:` block on purpose. docker.yml needs no caller-supplied secrets:
-    # its build job uses the automatic secrets.GITHUB_TOKEN (granted to called
-    # workflows without being passed, and undeclarable since the GITHUB_ prefix is
-    # reserved), and its deploy job reads the AZURE_* values as environment secrets
-    # of the `Development` environment it declares itself. Those environment secrets
-    # do not exist at this caller's scope, so forwarding them here would pass empty
-    # strings and break the deploy.
+    # `secrets: inherit` is load-bearing here — do not narrow it without reading
+    # this first. docker.yml's deploy job reads AZURE_CLIENT_ID / AZURE_TENANT_ID /
+    # AZURE_SUBSCRIPTION_ID / AZURE_CONTAINER_APP_NAME / AZURE_RESOURCE_GROUP, which
+    # exist ONLY as secrets of the `Development` environment that job declares.
+    #
+    # A called workflow's `secrets` context is populated solely from what the caller
+    # passes. Declaring `environment:` in the callee does not by itself pull that
+    # environment's secrets into scope — `inherit` is what lets the callee resolve
+    # secrets against the repository/environment store. Dropping it in #419 left
+    # client-id and tenant-id empty and broke `azure/login` on the first main push
+    # (run 31789136623); docker.yml was byte-identical to the last green run.
+    #
+    # Listing the AZURE_* secrets explicitly cannot work either: a job that `uses:`
+    # a reusable workflow may not declare `environment:`, so they are out of scope
+    # at this caller and would forward empty strings — the same failure.
+    secrets: inherit
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Fixes CD, broken on `main` since #419 merged.

## Symptom

First push to `main` after #419 (run [31789136623](https://github.com/vancodocton/MoneyGroup/actions/runs/31789136623)) — `deploy / deploy` → `Log in to Azure`:

```
Login failed with Error: Using auth-type: SERVICE_PRINCIPAL. Not all values are
present. Ensure 'client-id' and 'tenant-id' are supplied.
```

`AZURE_CLIENT_ID` / `AZURE_TENANT_ID` resolved to empty strings. The working run logs `client-id: ***`; the failing one omits the parameters entirely, which is how the runner renders empty inputs.

## Root cause

`secrets: inherit` is **not** a value copy of what the caller has in scope. It delegates secret *resolution* to the called workflow, which resolves against the repository/environment store — including the environment secrets of the environment its own job declares. Without it, a called workflow's `secrets` context holds only what the caller explicitly passed. `docker.yml`'s deploy job still declares `environment: Development`, but that alone does not pull environment secrets into scope.

#419 reasoned that since `gate.yml`'s deploy job declares no `environment:`, `inherit` could not have been supplying `AZURE_*`. Both premises were correct:

- `AZURE_*` are environment-scoped (`gh secret list --env Development` confirms all six)
- forwarding them from `gate.yml` would pass empty strings

but the conclusion did not follow — `inherit` *was* the mechanism.

## Isolation

`docker.yml` is byte-identical between the last green run (`703c039`) and the failing one (`9b5411c`):

```
git diff 703c039 9b5411c -- .github/workflows/docker.yml   # empty
```

The caller's `secrets:` block was the only changed variable on the deploy path.

## Change

`secrets: inherit` restored on the `deploy` call only, with a comment recording why it is load-bearing.

**#419's actual win is kept**: `backend` still forwards only `SONAR_TOKEN` and `CODECOV_TOKEN`, so `dotnet.yml` no longer receives the Azure credentials. Only the deploy call — which genuinely needs environment-secret resolution — goes back to `inherit`.

## Verification

- `deploy` job is functionally identical to `703c039` again (comment-stripped diff empty)
- all five workflow files parse
- asserted against parsed YAML: `deploy.secrets == 'inherit'`, `backend.secrets` still the explicit two-key map, `dotnet.yml`'s `workflow_call.secrets` declaration untouched, `deploy` still `needs: [changes, backend]` with `id-token: write`

⚠️ **PR checks cannot exercise this path.** `deploy / deploy` is gated on `do-deploy: github.ref == 'refs/heads/main'`, so it skips on every PR — exactly the blind spot that let #419 through. Verified separately by `workflow_dispatch` on a scratch branch; result posted as a comment below.

## Follow-up (not in this PR)

Real least-privilege on the deploy path means moving the deploy job out of `docker.yml` into `gate.yml`, where an ordinary job *can* declare `environment: Development` and resolve those secrets natively. That needs `docker.yml` to expose the digest as a `workflow_call` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
