### PR TITLE
test: unit-test foundation — relocate, lock idiom, close gaps (slice 1/4)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -36,6 +36,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
+    <PackageVersion Include="NSubstitute" Version="6.2.0" />
     <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.53.3" />
     <PackageVersion Include="SQLitePCLRaw.provider.e_sqlite3" Version="3.0.3" />

--- a/docs/superpowers/plans/2026-08-15-unit-test-foundation.md
+++ b/docs/superpowers/plans/2026-08-15-unit-test-foundation.md
@@ -1,0 +1,2501 @@
+# Unit-Test Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the 28 misplaced unit tests out of `FunctionalTests`, standardise the test idiom on NSubstitute + Given_When_Then + hand-written builders, and close the unit-testable coverage gaps.
+
+**Architecture:** One `test/UnitTests` project referencing `MoneyGroup.WebApi` (which transitively supplies `Core` and `Infrastructure`), with folders mirroring `src/`. Three phases: relocate without changing behaviour, then convert the idiom, then add new tests. Each task ends green.
+
+**Tech Stack:** .NET 10, xUnit v3 (`xunit.v3.mtp-v2` 3.2.2) on Microsoft.Testing.Platform, NSubstitute 6.2.0, FluentValidation 12.1.1, Ardalis.Specification 9.3.1, Riok.Mapperly 4.3.1.
+
+**Spec:** `docs/superpowers/specs/2026-08-15-unit-test-foundation-design.md`
+
+## Global Constraints
+
+- **`TreatWarningsAsErrors=true`** (`Directory.Build.props`). Never add `#pragma warning disable` — fix the cause.
+- **Central package management.** Every version goes in `Directory.Packages.props`; `<PackageReference>` in a csproj carries **no** `Version` attribute.
+- **Lock files.** `RestorePackagesWithLockFile=true`. Any package change requires the affected `packages.lock.json` to be regenerated and committed in the *same* commit, or CI fails under `RestoreLockedMode`.
+- **Never `git add -A` or `git add .`** Stage explicit paths. `src/WebApi/MoneyGroup.WebApi.json` is a generated OpenAPI document marked `text: auto`, and it re-churns line endings on every Windows build. `git diff --numstat` on it is empty when the change is line-endings only — discard it with `git checkout -- src/WebApi/MoneyGroup.WebApi.json`.
+- **Assertions stay on xUnit `Assert`.** Shouldly is explicitly deferred (spec decision D6). Do not introduce it.
+- **`testconfig.json` must not be modified.** The coverage-config correction is deliberately deferred; the low coverage percentage is expected. See the spec's *Deferred* section.
+- **Test naming is `Given_When_Then`.** Class-name suffix is `Tests` (plural).
+- **Cancellation tokens in tests use `TestContext.Current.CancellationToken`** (xUnit v3), never `default` or `CancellationToken.None`, except where asserting a specific token value.
+- Run all commands from the worktree root: `D:\source\vancodocton\MoneyGroup\.claude\worktrees\test-unit-foundation`.
+
+## Baseline
+
+`main` @ `fc33b0a` — **63 tests, 0 failures, 2 skipped.** UnitTests 8, IntegrationTests 6, FunctionalTests 48, AppHost.Tests 1.
+
+Full-suite runs need a seeded database first (the functional suite corrupts its own seed; fixed in a later slice):
+
+```bash
+docker compose up -d --wait mssql
+docker exec -w /mssql-server-setup-scripts.d moneygroup-mssql-1 bash ./reset.sh
+```
+
+The fast loop used by most tasks needs no database:
+
+```bash
+dotnet test test/UnitTests/MoneyGroup.UnitTests.csproj
+```
+
+---
+
+# Phase 1 — Relocation
+
+Pure motion. **Total test count must remain exactly 63 through the entire phase.**
+
+---
+
+### Task 1: Give UnitTests access to WebApi
+
+**Files:**
+- Modify: `test/UnitTests/MoneyGroup.UnitTests.csproj`
+- Modify: `test/UnitTests/packages.lock.json` (regenerated)
+
+**Interfaces:**
+- Consumes: nothing
+- Produces: `MoneyGroup.UnitTests` can reference types from `MoneyGroup.WebApi`, `MoneyGroup.Core` and `MoneyGroup.Infrastructure`.
+
+- [ ] **Step 1: Record the baseline test count**
+
+```bash
+dotnet test --solution MoneyGroup.slnx
+```
+
+Expected: `total: 63`, `failed: 0`, `skipped: 2`. If the functional tests fail, run the seed reset from the Baseline section and re-run.
+
+- [ ] **Step 2: Add the project reference**
+
+In `test/UnitTests/MoneyGroup.UnitTests.csproj`, replace the existing `ProjectReference` item group:
+
+```xml
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Core\MoneyGroup.Core.csproj" />
+  </ItemGroup>
+```
+
+with:
+
+```xml
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\WebApi\MoneyGroup.WebApi.csproj" />
+  </ItemGroup>
+```
+
+`WebApi` already references `Core` and `Infrastructure`, so one reference covers all three.
+
+- [ ] **Step 3: Regenerate the lock file**
+
+```bash
+dotnet restore test/UnitTests/MoneyGroup.UnitTests.csproj --force-evaluate
+```
+
+Expected: `test/UnitTests/packages.lock.json` is rewritten with the new transitive graph.
+
+- [ ] **Step 4: Verify nothing broke**
+
+```bash
+dotnet test test/UnitTests/MoneyGroup.UnitTests.csproj
+```
+
+Expected: PASS, `total: 8`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/UnitTests/MoneyGroup.UnitTests.csproj test/UnitTests/packages.lock.json
+git commit -m "test: reference WebApi from UnitTests
+
+Prepares UnitTests to receive the validator and authorization tests
+currently misplaced in FunctionalTests. WebApi transitively supplies
+Core and Infrastructure."
+```
+
+---
+
+### Task 2: Relocate OrderServiceTest
+
+**Files:**
+- Delete: `test/UnitTests/Services/OrderServiceTest.cs`
+- Create: `test/UnitTests/Core/Services/OrderServiceTests.cs`
+
+**Interfaces:**
+- Consumes: Task 1's project reference
+- Produces: class `MoneyGroup.UnitTests.Core.Services.OrderServiceTests` — 8 tests, still Moq-based.
+
+- [ ] **Step 1: Move the file**
+
+```bash
+git mv test/UnitTests/Services/OrderServiceTest.cs test/UnitTests/Core/Services/OrderServiceTests.cs
+```
+
+- [ ] **Step 2: Update the namespace, class name and field type**
+
+In `test/UnitTests/Core/Services/OrderServiceTests.cs`:
+
+Change the namespace line from `namespace MoneyGroup.UnitTests.Services;` to:
+
+```csharp
+namespace MoneyGroup.UnitTests.Core.Services;
+```
+
+Change the class declaration and remove the pragma. Replace:
+
+```csharp
+public class OrderServiceTest
+{
+    private readonly Mock<IUserRepository> _userRepositoryMock;
+    private readonly Mock<IOrderRepository> _orderRepositoryMock;
+#pragma warning disable CA1859 // Use concrete types when possible for improved performance
+    private readonly IOrderService _orderService;
+#pragma warning restore CA1859 // Use concrete types when possible for improved performance
+
+    public OrderServiceTest()
+```
+
+with:
+
+```csharp
+[Trait("Category", "Unit")]
+public class OrderServiceTests
+{
+    private readonly Mock<IUserRepository> _userRepositoryMock;
+    private readonly Mock<IOrderRepository> _orderRepositoryMock;
+    private readonly OrderService _orderService;
+
+    public OrderServiceTests()
+```
+
+Typing the field as the concrete `OrderService` is what retires `CA1859`; the pragma is no longer needed and must not be reintroduced.
+
+- [ ] **Step 3: Run tests**
+
+```bash
+dotnet test test/UnitTests/MoneyGroup.UnitTests.csproj
+```
+
+Expected: PASS, `total: 8`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/UnitTests/Core/Services/OrderServiceTests.cs
+git commit -m "test: relocate OrderServiceTest to Core/Services
+
+Mirrors src/ layout. Retires the CA1859 pragma by typing the field as
+the concrete OrderService."
+```
+
+---
+
+### Task 3: Relocate the validator tests
+
+**Files:**
+- Delete: `test/FunctionalTests/Validators/OrderDtoValidatorTest.cs`
+- Delete: `test/FunctionalTests/Validators/OrderPaginatedRequestValidatorTests.cs`
+- Delete: `test/FunctionalTests/Validators/ParticipantDtoValidatorTest.cs`
+- Create: `test/UnitTests/WebApi/Validators/OrderDtoValidatorTests.cs`
+- Create: `test/UnitTests/WebApi/Validators/OrderPaginatedRequestValidatorTests.cs`
+- Create: `test/UnitTests/WebApi/Validators/ParticipantDtoValidatorTests.cs`
+
+**Interfaces:**
+- Consumes: Task 1's project reference
+- Produces: 23 tests in namespace `MoneyGroup.UnitTests.WebApi.Validators`.
+
+- [ ] **Step 1: Move the three files**
+
+```bash
+git mv test/FunctionalTests/Validators/OrderDtoValidatorTest.cs test/UnitTests/WebApi/Validators/OrderDtoValidatorTests.cs
+git mv test/FunctionalTests/Validators/OrderPaginatedRequestValidatorTests.cs test/UnitTests/WebApi/Validators/OrderPaginatedRequestValidatorTests.cs
+git mv test/FunctionalTests/Validators/ParticipantDtoValidatorTest.cs test/UnitTests/WebApi/Validators/ParticipantDtoValidatorTests.cs
+```
+
+- [ ] **Step 2: Fix OrderDtoValidatorTests — namespace, name, and delete the pointless fixture**
+
+In `test/UnitTests/WebApi/Validators/OrderDtoValidatorTests.cs`, replace everything from `namespace` down to the end of the constructor:
+
+```csharp
+namespace MoneyGroup.FunctionalTests.Validators;
+
+public class OrderDtoValidatorTestFixture
+{
+    public OrderDtoValidator Validator { get; }
+
+    public OrderDtoValidatorTestFixture()
+    {
+        Validator = new OrderDtoValidator(new ParticipantDtoValidator());
+    }
+}
+
+public class OrderDtoValidatorTest
+    : IClassFixture<OrderDtoValidatorTestFixture>
+{
+    private readonly OrderDtoValidator _validator;
+
+    public OrderDtoValidatorTest(OrderDtoValidatorTestFixture fixture)
+    {
+        _validator = fixture.Validator;
+    }
+```
+
+with:
+
+```csharp
+namespace MoneyGroup.UnitTests.WebApi.Validators;
+
+[Trait("Category", "Unit")]
+public class OrderDtoValidatorTests
+{
+    private readonly OrderDtoValidator _validator = new(new ParticipantDtoValidator());
+```
+
+The fixture existed only to cache a stateless, allocation-free validator.
+
+- [ ] **Step 3: Fix ParticipantDtoValidatorTests — stop using a production type as a fixture**
+
+In `test/UnitTests/WebApi/Validators/ParticipantDtoValidatorTests.cs`, replace:
+
+```csharp
+namespace MoneyGroup.FunctionalTests.Validators;
+
+public class ParticipantDtoValidatorTest
+    : IClassFixture<ParticipantDtoValidator>
+{
+    private readonly ParticipantDtoValidator _validator;
+
+    public ParticipantDtoValidatorTest(ParticipantDtoValidator validator)
+    {
+        _validator = validator;
+    }
+```
+
+with:
+
+```csharp
+namespace MoneyGroup.UnitTests.WebApi.Validators;
+
+[Trait("Category", "Unit")]
+public class ParticipantDtoValidatorTests
+{
+    private readonly ParticipantDtoValidator _validator = new();
+```
+
+- [ ] **Step 4: Fix OrderPaginatedRequestValidatorTests — namespace and class name only**
+
+In `test/UnitTests/WebApi/Validators/OrderPaginatedRequestValidatorTests.cs`, change:
+
+```csharp
+namespace MoneyGroup.FunctionalTests.Validators;
+
+public class OrderPaginatedRequestValidatorTests
+{
+```
+
+to:
+
+```csharp
+namespace MoneyGroup.UnitTests.WebApi.Validators;
+
+[Trait("Category", "Unit")]
+public class OrderPaginatedRequestValidatorTests
+{
+```
+
+- [ ] **Step 5: Run both projects**
+
+```bash
+dotnet test test/UnitTests/MoneyGroup.UnitTests.csproj
+```
+
+Expected: PASS, `total: 31` (8 + 23).
+
+```bash
+dotnet test test/FunctionalTests/MoneyGroup.FunctionalTests.csproj
+```
+
+Expected: PASS, `total: 25` (48 − 23), `skipped: 2`. If `DeleteOrder_ValidId_ReturnsNoContent` fails, run the seed reset — that failure is the known, deferred seed-corruption issue, not a regression from this task.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add test/UnitTests/WebApi/Validators test/FunctionalTests/Validators
+git commit -m "test: relocate validator tests to UnitTests
+
+These 23 tests never start a host or touch a database. Also removes
+OrderDtoValidatorTestFixture (cached a stateless object) and stops
+ParticipantDtoValidatorTests using a production type as an
+IClassFixture."
+```
+
+---
+
+### Task 4: Relocate the authorization handler test
+
+**Files:**
+- Delete: `test/FunctionalTests/Authorizations/DenyUnauthorizedUserHandlerTest.cs`
+- Create: `test/UnitTests/WebApi/Authorizations/DenyUnauthorizedUserHandlerTests.cs`
+
+**Interfaces:**
+- Consumes: Task 1's project reference
+- Produces: 5 tests in namespace `MoneyGroup.UnitTests.WebApi.Authorizations`. Still Moq-based; converted in Task 8.
+
+- [ ] **Step 1: Move the file**
+
+```bash
+git mv test/FunctionalTests/Authorizations/DenyUnauthorizedUserHandlerTest.cs test/UnitTests/WebApi/Authorizations/DenyUnauthorizedUserHandlerTests.cs
+```
+
+- [ ] **Step 2: Update namespace and class name**
+
+Change:
+
+```csharp
+namespace MoneyGroup.FunctionalTests.Authorizations;
+
+public class DenyUnauthorizedUserHandlerTest
+{
+```
+
+to:
+
+```csharp
+namespace MoneyGroup.UnitTests.WebApi.Authorizations;
+
+[Trait("Category", "Unit")]
+public class DenyUnauthorizedUserHandlerTests
+{
+```
+
+Also rename the constructor from `DenyUnauthorizedUserHandlerTest()` to `DenyUnauthorizedUserHandlerTests()`.
+
+- [ ] **Step 3: Build and fix the JWT claim-names namespace if needed**
+
+```bash
+dotnet build test/UnitTests/MoneyGroup.UnitTests.csproj
+```
+
+The file currently imports `System.IdentityModel.Tokens.Jwt`. If the build fails with `CS0246` on `JwtRegisteredClaimNames`, replace that using directive with the one production code uses:
+
+```csharp
+using Microsoft.IdentityModel.JsonWebTokens;
+```
+
+Both types define `EmailVerified` as the string `"email_verified"`, so no test behaviour changes. `DenyUnauthorizedUserHandler` itself uses the `Microsoft.IdentityModel.JsonWebTokens` variant, so aligning is correct regardless.
+
+- [ ] **Step 4: Run both projects**
+
+```bash
+dotnet test test/UnitTests/MoneyGroup.UnitTests.csproj
+```
+
+Expected: PASS, `total: 36` (31 + 5).
+
+```bash
+dotnet test test/FunctionalTests/MoneyGroup.FunctionalTests.csproj
+```
+
+Expected: PASS, `total: 20`, `skipped: 2`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/UnitTests/WebApi/Authorizations test/FunctionalTests/Authorizations
+git commit -m "test: relocate DenyUnauthorizedUserHandler test to UnitTests
+
+Uses Moq and NullLoggerFactory only; no host, no HTTP, no database.
+FunctionalTests is now 20 genuinely-functional tests."
+```
+
+---
+
+### Task 5: Drop Moq from FunctionalTests and confirm parity
+
+**Files:**
+- Modify: `test/FunctionalTests/MoneyGroup.FunctionalTests.csproj`
+- Modify: `test/FunctionalTests/packages.lock.json` (regenerated)
+
+**Interfaces:**
+- Consumes: Tasks 3 and 4 having emptied the mocking usage out of `FunctionalTests`
+- Produces: `FunctionalTests` with no mocking dependency.
+
+- [ ] **Step 1: Confirm nothing in FunctionalTests still uses Moq**
+
+```bash
+grep -rn "Moq" test/FunctionalTests --include=*.cs
+```
+
+Expected: no output.
+
+- [ ] **Step 2: Remove the package reference**
+
+In `test/FunctionalTests/MoneyGroup.FunctionalTests.csproj`, delete this line from the `PackageReference` item group:
+
+```xml
+    <PackageReference Include="Moq" />
+```
+
+- [ ] **Step 3: Regenerate the lock file**
+
+```bash
+dotnet restore test/FunctionalTests/MoneyGroup.FunctionalTests.csproj --force-evaluate
+```
+
+- [ ] **Step 4: Verify full-suite parity**
+
+```bash
+docker exec -w /mssql-server-setup-scripts.d moneygroup-mssql-1 bash ./reset.sh
+dotnet test --solution MoneyGroup.slnx
+```
+
+Expected: `total: 63`, `failed: 0`, `skipped: 2` — **identical to the Phase 1 baseline.** Any other number means a test was lost in a move; do not proceed until it is 63.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/FunctionalTests/MoneyGroup.FunctionalTests.csproj test/FunctionalTests/packages.lock.json
+git commit -m "test: drop Moq from FunctionalTests
+
+Nothing there mocks any more. Phase 1 complete: 63 tests before and
+after, now distributed 36 unit / 6 integration / 20 functional / 1 smoke."
+```
+
+---
+
+# Phase 2 — Lock the idiom
+
+Still 63 tests throughout.
+
+---
+
+### Task 6: Add NSubstitute
+
+**Files:**
+- Modify: `Directory.Packages.props`
+- Modify: `test/UnitTests/MoneyGroup.UnitTests.csproj`
+- Modify: `test/UnitTests/packages.lock.json` (regenerated)
+
+**Interfaces:**
+- Produces: `NSubstitute` available in `MoneyGroup.UnitTests`, alongside Moq during the transition.
+
+- [ ] **Step 1: Pin the version centrally**
+
+In `Directory.Packages.props`, add this line to the `ItemGroup`, keeping alphabetical order (immediately after the `Moq` line):
+
+```xml
+    <PackageVersion Include="NSubstitute" Version="6.2.0" />
+```
+
+- [ ] **Step 2: Reference it from UnitTests**
+
+In `test/UnitTests/MoneyGroup.UnitTests.csproj`, add to the `PackageReference` item group (note: no `Version` attribute — central package management supplies it):
+
+```xml
+    <PackageReference Include="NSubstitute" />
+```
+
+- [ ] **Step 3: Regenerate the lock file**
+
+```bash
+dotnet restore test/UnitTests/MoneyGroup.UnitTests.csproj --force-evaluate
+```
+
+- [ ] **Step 4: Verify the build still passes**
+
+```bash
+dotnet test test/UnitTests/MoneyGroup.UnitTests.csproj
+```
+
+Expected: PASS, `total: 36`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Directory.Packages.props test/UnitTests/MoneyGroup.UnitTests.csproj test/UnitTests/packages.lock.json
+git commit -m "test: add NSubstitute 6.2.0 to UnitTests
+
+Coexists with Moq for the duration of the conversion."
+```
+
+---
+
+### Task 7: Convert OrderServiceTests to NSubstitute
+
+**Files:**
+- Modify: `test/UnitTests/Core/Services/OrderServiceTests.cs`
+
+**Interfaces:**
+- Consumes: NSubstitute from Task 6
+- Produces: `OrderServiceTests` with no Moq usage.
+
+> **Critical:** Moq's `Verify` throws when the call did not happen. NSubstitute's equivalent is `Received()`, and **a forgotten `Received()` assertion passes silently** — the test still goes green while verifying nothing. Every `Verify` below must become an explicit `Received`/`DidNotReceive`. Calls returning `Task` must be awaited: `await sub.Received(1).Method(...)`.
+
+- [ ] **Step 1: Replace the using directive and the fields**
+
+Replace `using Moq;` with:
+
+```csharp
+using NSubstitute;
+```
+
+Replace the field declarations and constructor body:
+
+```csharp
+    private readonly Mock<IUserRepository> _userRepositoryMock;
+    private readonly Mock<IOrderRepository> _orderRepositoryMock;
+    private readonly OrderService _orderService;
+
+    public OrderServiceTests()
+    {
+        _userRepositoryMock = new Mock<IUserRepository>();
+        _orderRepositoryMock = new Mock<IOrderRepository>();
+        _orderService = new OrderService(_orderRepositoryMock.Object, _userRepositoryMock.Object);
+    }
+```
+
+with:
+
+```csharp
+    private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
+    private readonly IOrderRepository _orderRepository = Substitute.For<IOrderRepository>();
+    private readonly OrderService _orderService;
+
+    public OrderServiceTests()
+    {
+        _orderService = new OrderService(_orderRepository, _userRepository);
+    }
+```
+
+- [ ] **Step 2: Convert `GetOrderByIdAsync_ValidId_ShouldReturnOrder`**
+
+Replace the body with:
+
+```csharp
+        // Arrange
+        var id = 1;
+        var orderDto = new OrderDetailedDto { Id = id };
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        _orderRepository
+            .FirstOrDefaultAsync<OrderDetailedDto>(Arg.Any<EntityByIdSpec<Order>>(), cancellationToken)
+            .Returns(orderDto);
+
+        // Act
+        var result = await _orderService.GetOrderByIdAsync(id, cancellationToken);
+
+        // Assert
+        await _orderRepository.Received(1)
+            .FirstOrDefaultAsync<OrderDetailedDto>(Arg.Any<EntityByIdSpec<Order>>(), cancellationToken);
+        Assert.NotNull(result);
+        Assert.Equal(id, result.Id);
+```
+
+- [ ] **Step 3: Convert `GetOrderByIdAsync_InvalidId_ShouldReturnNull`**
+
+```csharp
+        // Arrange
+        var invalidId = -1;
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        _orderRepository
+            .FirstOrDefaultAsync<OrderDetailedDto>(Arg.Any<EntityByIdSpec<Order>>(), cancellationToken)
+            .Returns((OrderDetailedDto?)null);
+
+        // Act
+        var result = await _orderService.GetOrderByIdAsync(invalidId, cancellationToken);
+
+        // Assert
+        await _orderRepository.Received(1)
+            .FirstOrDefaultAsync<OrderDetailedDto>(Arg.Any<EntityByIdSpec<Order>>(), cancellationToken);
+        Assert.Null(result);
+```
+
+- [ ] **Step 4: Convert `CreateOrderAsync_ValidDto_ShouldAddOrder`**
+
+```csharp
+        // Arrange
+        var newOrderId = 1;
+        var model = new OrderDto
+        {
+            BuyerId = 1,
+            Participants =
+            [
+                new() { ParticipantId = 2 },
+                new() { ParticipantId = 3 },
+            ],
+        };
+
+        _userRepository.AnyAsync(Arg.Any<EntityByIdSpec<User>>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+        _userRepository.CountAsync(Arg.Any<EntityByIdsSpec<User>>(), Arg.Any<CancellationToken>())
+            .Returns(2);
+        _orderRepository.AddAsync(Arg.Any<OrderDto>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                model.Id = newOrderId;
+                return model;
+            });
+
+        // Act
+        await _orderService.CreateOrderAsync(model, TestContext.Current.CancellationToken);
+
+        // Assert
+        await _userRepository.Received(1).AnyAsync(Arg.Any<EntityByIdSpec<User>>(), Arg.Any<CancellationToken>());
+        await _userRepository.Received(1).CountAsync(Arg.Any<EntityByIdsSpec<User>>(), Arg.Any<CancellationToken>());
+        await _orderRepository.Received(1).AddAsync(Arg.Any<OrderDto>(), Arg.Any<CancellationToken>());
+        Assert.Equal(newOrderId, model.Id);
+```
+
+- [ ] **Step 5: Convert `CreateOrderAsync_NoParticipants_ShouldAddOrder`**
+
+```csharp
+        // Arrange
+        var newOrderId = 1;
+        var model = new OrderDto
+        {
+            BuyerId = 1,
+            Participants = [],
+        };
+
+        _userRepository.AnyAsync(Arg.Any<EntityByIdSpec<User>>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+        _orderRepository.AddAsync(Arg.Any<OrderDto>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                model.Id = newOrderId;
+                return model;
+            });
+
+        // Act
+        await _orderService.CreateOrderAsync(model, TestContext.Current.CancellationToken);
+
+        // Assert
+        await _userRepository.Received(1).AnyAsync(Arg.Any<EntityByIdSpec<User>>(), Arg.Any<CancellationToken>());
+        await _userRepository.DidNotReceive().CountAsync(Arg.Any<EntityByIdsSpec<User>>(), Arg.Any<CancellationToken>());
+        await _orderRepository.Received(1).AddAsync(Arg.Any<OrderDto>(), Arg.Any<CancellationToken>());
+        Assert.Equal(newOrderId, model.Id);
+```
+
+- [ ] **Step 6: Convert `CreateOrderAsync_InvalidBuyer_ShouldThrowInvalidOperationException`**
+
+```csharp
+        // Arrange
+        var model = new OrderDto
+        {
+            BuyerId = -1,
+            Participants =
+            [
+                new() { ParticipantId = 2 },
+                new() { ParticipantId = 3 },
+            ],
+        };
+
+        _userRepository.AnyAsync(Arg.Any<EntityByIdSpec<User>>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        // Act
+        var ex = await Assert.ThrowsAsync<BuyerNotFoundException>(
+            () => _orderService.CreateOrderAsync(model, TestContext.Current.CancellationToken));
+
+        // Assert
+        await _userRepository.Received(1).AnyAsync(Arg.Any<EntityByIdSpec<User>>(), Arg.Any<CancellationToken>());
+        await _orderRepository.DidNotReceive().AddAsync(Arg.Any<OrderDto>(), Arg.Any<CancellationToken>());
+        Assert.Equal("Buyer not found", ex.Message);
+```
+
+- [ ] **Step 7: Convert `CreateOrderAsync_InvalidParticipants_ShouldThrowInvalidOperationException`**
+
+```csharp
+        // Arrange
+        var model = new OrderDto
+        {
+            BuyerId = 1,
+            Participants =
+            [
+                new() { ParticipantId = 2 },
+                new() { ParticipantId = -1 },
+            ],
+        };
+
+        _userRepository.AnyAsync(Arg.Any<EntityByIdSpec<User>>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+        _userRepository.CountAsync(Arg.Any<EntityByIdsSpec<User>>(), Arg.Any<CancellationToken>())
+            .Returns(1); // only 1 of the 2 requested participants exists
+
+        // Act
+        var ex = await Assert.ThrowsAsync<ParticipantNotFoundException>(
+            () => _orderService.CreateOrderAsync(model, TestContext.Current.CancellationToken));
+
+        // Assert
+        await _userRepository.Received(1).AnyAsync(Arg.Any<EntityByIdSpec<User>>(), Arg.Any<CancellationToken>());
+        await _userRepository.Received(1).CountAsync(Arg.Any<EntityByIdsSpec<User>>(), Arg.Any<CancellationToken>());
+        await _orderRepository.DidNotReceive().AddAsync(Arg.Any<OrderDto>(), Arg.Any<CancellationToken>());
+        Assert.Equal("Participant not found", ex.Message);
+```
+
+- [ ] **Step 8: Convert `RemoveOrderAsync_OrderExists_ShouldRemoveOrder`**
+
+NSubstitute returns a completed `Task` by default, so the `RemoveAsync` setup line disappears entirely.
+
+```csharp
+        // Arrange
+        var orderId = 1;
+        var order = new Order { Id = orderId };
+
+        _orderRepository.FirstOrDefaultAsync(Arg.Any<EntityByIdSpec<Order>>(), Arg.Any<CancellationToken>())
+            .Returns(order);
+
+        // Act
+        var result = await _orderService.RemoveOrderAsync(orderId, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.True(result);
+        await _orderRepository.Received(1).FirstOrDefaultAsync(Arg.Any<EntityByIdSpec<Order>>(), Arg.Any<CancellationToken>());
+        await _orderRepository.Received(1).RemoveAsync(order, Arg.Any<CancellationToken>());
+```
+
+- [ ] **Step 9: Convert `RemoveOrderAsync_OrderNotFound_ShouldThrowInvalidOperationException`**
+
+```csharp
+        // Arrange
+        var orderId = 1;
+
+        _orderRepository.FirstOrDefaultAsync(Arg.Any<EntityByIdSpec<Order>>(), Arg.Any<CancellationToken>())
+            .Returns((Order?)null);
+
+        // Act
+        var result = await _orderService.RemoveOrderAsync(orderId, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(result);
+        await _orderRepository.Received(1).FirstOrDefaultAsync(Arg.Any<EntityByIdSpec<Order>>(), Arg.Any<CancellationToken>());
+        await _orderRepository.DidNotReceive().RemoveAsync(Arg.Any<Order>(), Arg.Any<CancellationToken>());
+```
+
+- [ ] **Step 10: Confirm no Moq remains in this file**
+
+```bash
+grep -n "Moq\|Mock<\|\.Object\|It\.IsAny\|Times\." test/UnitTests/Core/Services/OrderServiceTests.cs
+```
+
+Expected: no output.
+
+- [ ] **Step 11: Run tests**
+
+```bash
+dotnet test test/UnitTests/MoneyGroup.UnitTests.csproj
+```
+
+Expected: PASS, `total: 36`.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add test/UnitTests/Core/Services/OrderServiceTests.cs
+git commit -m "test: convert OrderServiceTests to NSubstitute
+
+Every Moq Verify becomes an explicit Received/DidNotReceive. Also
+replaces 'default' cancellation tokens with
+TestContext.Current.CancellationToken."
+```
+
+---
+
+### Task 8: Convert the authorization handler test and retire Moq
+
+**Files:**
+- Modify: `test/UnitTests/WebApi/Authorizations/DenyUnauthorizedUserHandlerTests.cs`
+- Modify: `test/UnitTests/MoneyGroup.UnitTests.csproj`
+- Modify: `test/UnitTests/packages.lock.json` (regenerated)
+
+**Interfaces:**
+- Consumes: NSubstitute from Task 6
+- Produces: no Moq anywhere in the solution. A real `ClaimsPrincipal` replaces `Mock<ClaimsPrincipal>`.
+
+> The current test mocks `ClaimsPrincipal.FindFirst` while production calls the `FindFirstValue` **extension method**, which internally delegates to `FindFirst`. That couples the test to a BCL implementation detail. A real `ClaimsPrincipal` removes the coupling and is shorter.
+
+- [ ] **Step 1: Replace the whole file**
+
+Write `test/UnitTests/WebApi/Authorizations/DenyUnauthorizedUserHandlerTests.cs`:
+
+```csharp
+using System.Security.Claims;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.IdentityModel.JsonWebTokens;
+
+using MoneyGroup.Core.Abstractions;
+using MoneyGroup.Core.Models.Users;
+using MoneyGroup.WebApi.Authorizations;
+
+using NSubstitute;
+
+namespace MoneyGroup.UnitTests.WebApi.Authorizations;
+
+[Trait("Category", "Unit")]
+public class DenyUnauthorizedUserHandlerTests
+{
+    private const string Email = "user@domain.com";
+
+    private readonly IUserService _userService = Substitute.For<IUserService>();
+    private readonly DenyUnauthorizedUserHandler _handler;
+
+    public DenyUnauthorizedUserHandlerTests()
+    {
+        _handler = new DenyUnauthorizedUserHandler(
+            NullLoggerFactory.Instance.CreateLogger<DenyUnauthorizedUserHandler>(),
+            _userService);
+    }
+
+    private static AuthorizationHandlerContext ContextFor(ClaimsPrincipal user) =>
+        new([new DenyUnauthorizedUserRequirement()], user, resource: null);
+
+    private static ClaimsPrincipal Anonymous() => new(new ClaimsIdentity());
+
+    private static ClaimsPrincipal Authenticated(params Claim[] claims) =>
+        new(new ClaimsIdentity(claims, authenticationType: "TestAuth"));
+
+    [Fact]
+    public async Task GivenUser_WhenNotAuthenticated_ThenDoesNotSucceed()
+    {
+        // Arrange
+        var context = ContextFor(Anonymous());
+
+        // Act
+        await _handler.HandleAsync(context);
+
+        // Assert
+        Assert.False(context.HasSucceeded);
+    }
+
+    [Fact]
+    public async Task GivenUser_WhenEmailClaimMissing_ThenDoesNotSucceed()
+    {
+        // Arrange
+        var context = ContextFor(Authenticated());
+
+        // Act
+        await _handler.HandleAsync(context);
+
+        // Assert
+        Assert.False(context.HasSucceeded);
+    }
+
+    [Fact]
+    public async Task GivenUser_WhenEmailVerifiedClaimMissing_ThenDoesNotSucceed()
+    {
+        // Arrange
+        var context = ContextFor(Authenticated(new Claim(ClaimTypes.Email, Email)));
+
+        // Act
+        await _handler.HandleAsync(context);
+
+        // Assert
+        Assert.False(context.HasSucceeded);
+    }
+
+    [Fact]
+    public async Task GivenVerifiedEmail_WhenUserNotFound_ThenDoesNotSucceed()
+    {
+        // Arrange
+        var context = ContextFor(Authenticated(
+            new Claim(ClaimTypes.Email, Email),
+            new Claim(JwtRegisteredClaimNames.EmailVerified, "true")));
+
+        _userService.GetUserByEmailAsync(Email, Arg.Any<CancellationToken>())
+            .Returns((UserDto?)null);
+
+        // Act
+        await _handler.HandleAsync(context);
+
+        // Assert
+        Assert.False(context.HasSucceeded);
+        await _userService.Received(1).GetUserByEmailAsync(Email, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GivenVerifiedEmail_WhenUserFound_ThenSucceeds()
+    {
+        // Arrange
+        var context = ContextFor(Authenticated(
+            new Claim(ClaimTypes.Email, Email),
+            new Claim(JwtRegisteredClaimNames.EmailVerified, "true")));
+
+        _userService.GetUserByEmailAsync(Email, Arg.Any<CancellationToken>())
+            .Returns(new UserDto { Id = 1, Name = "User", Email = Email });
+
+        // Act
+        await _handler.HandleAsync(context);
+
+        // Assert
+        Assert.True(context.HasSucceeded);
+        await _userService.Received(1).GetUserByEmailAsync(Email, Arg.Any<CancellationToken>());
+    }
+}
+```
+
+This file also completes the Given_When_Then rename for these five tests, so Task 9 does not touch it.
+
+- [ ] **Step 2: Remove the Moq package reference**
+
+In `test/UnitTests/MoneyGroup.UnitTests.csproj`, delete:
+
+```xml
+    <PackageReference Include="Moq" />
+```
+
+- [ ] **Step 3: Regenerate the lock file**
+
+```bash
+dotnet restore test/UnitTests/MoneyGroup.UnitTests.csproj --force-evaluate
+```
+
+- [ ] **Step 4: Confirm Moq is gone from the whole solution**
+
+```bash
+grep -rn "Moq" test --include=*.cs --include=*.csproj
+```
+
+Expected: no output.
+
+- [ ] **Step 5: Run tests**
+
+```bash
+dotnet test test/UnitTests/MoneyGroup.UnitTests.csproj
+```
+
+Expected: PASS, `total: 36`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add test/UnitTests/WebApi/Authorizations/DenyUnauthorizedUserHandlerTests.cs test/UnitTests/MoneyGroup.UnitTests.csproj test/UnitTests/packages.lock.json
+git commit -m "test: convert authz handler test to NSubstitute, drop Moq
+
+Replaces Mock<ClaimsPrincipal> with a real ClaimsPrincipal, removing
+the coupling to FindFirstValue's internal use of FindFirst. Moq is now
+absent from the solution."
+```
+
+---
+
+### Task 9: Rename remaining tests to Given_When_Then
+
+**Files:**
+- Modify: `test/UnitTests/Core/Services/OrderServiceTests.cs`
+- Modify: `test/UnitTests/WebApi/Validators/OrderDtoValidatorTests.cs`
+- Modify: `test/UnitTests/WebApi/Validators/OrderPaginatedRequestValidatorTests.cs`
+- Modify: `test/UnitTests/WebApi/Validators/ParticipantDtoValidatorTests.cs`
+
+**Interfaces:**
+- Produces: every test method in `UnitTests` named `Given…_When…_Then…`.
+
+`OrderDtoValidatorTests` already uses this convention; only its `GivenOrderDto_WhenValid_ThenReturnNoError` style needs the `Then` verb normalised. `DenyUnauthorizedUserHandlerTests` was renamed in Task 8.
+
+- [ ] **Step 1: Rename the OrderServiceTests methods**
+
+| From | To |
+|---|---|
+| `GetOrderByIdAsync_ValidId_ShouldReturnOrder` | `GivenOrderId_WhenOrderExists_ThenReturnsOrder` |
+| `GetOrderByIdAsync_InvalidId_ShouldReturnNull` | `GivenOrderId_WhenOrderMissing_ThenReturnsNull` |
+| `CreateOrderAsync_ValidDto_ShouldAddOrder` | `GivenOrder_WhenBuyerAndParticipantsExist_ThenAddsOrder` |
+| `CreateOrderAsync_NoParticipants_ShouldAddOrder` | `GivenOrder_WhenNoParticipants_ThenAddsOrderWithoutCountingParticipants` |
+| `CreateOrderAsync_InvalidBuyer_ShouldThrowInvalidOperationException` | `GivenOrder_WhenBuyerMissing_ThenThrowsBuyerNotFound` |
+| `CreateOrderAsync_InvalidParticipants_ShouldThrowInvalidOperationException` | `GivenOrder_WhenAnyParticipantMissing_ThenThrowsParticipantNotFound` |
+| `RemoveOrderAsync_OrderExists_ShouldRemoveOrder` | `GivenOrderId_WhenOrderExists_ThenRemovesOrderAndReturnsTrue` |
+| `RemoveOrderAsync_OrderNotFound_ShouldThrowInvalidOperationException` | `GivenOrderId_WhenOrderMissing_ThenReturnsFalse` |
+
+The last two old names were actively wrong — neither throws.
+
+- [ ] **Step 2: Rename the OrderPaginatedRequestValidatorTests methods**
+
+| From | To |
+|---|---|
+| `Should_Have_Error_When_BuyerId_Is_Less_Than_Or_Equal_To_Zero` | `GivenRequest_WhenBuyerIdNotPositive_ThenHasErrorForBuyerId` |
+| `Should_Have_Error_When_ParticipantId_Is_Less_Than_Or_Equal_To_Zero` | `GivenRequest_WhenParticipantIdNotPositive_ThenHasErrorForParticipantId` |
+| `Should_Have_Error_When_TotalMax_Is_Less_Than_Or_Equal_To_Zero` | `GivenRequest_WhenTotalMaxNotPositive_ThenHasErrorForTotalMax` |
+| `Should_Have_Error_When_TotalMin_Is_Less_Than_Or_Equal_To_Zero` | `GivenRequest_WhenTotalMinNotPositive_ThenHasErrorForTotalMin` |
+| `Should_Have_Error_When_TotalMin_Is_Greater_Than_TotalMax` | `GivenRequest_WhenTotalMinExceedsTotalMax_ThenHasErrorForTotalMin` |
+| `Should_Have_Error_When_Page_Is_Less_Than_One` | `GivenRequest_WhenPageBelowOne_ThenHasErrorForPage` |
+| `Should_Have_Error_When_Size_Is_Less_Than_One` | `GivenRequest_WhenSizeBelowOne_ThenHasErrorForSize` |
+| `Should_Not_Have_Error_When_Valid_Model` | `GivenRequest_WhenValid_ThenHasNoErrors` |
+
+- [ ] **Step 3: Rename the ParticipantDtoValidatorTests method**
+
+| From | To |
+|---|---|
+| `GivenOrderDto_WhenParticipantIdZero_ThenReturnError` | `GivenParticipant_WhenParticipantIdZero_ThenHasErrorForParticipantId` |
+
+- [ ] **Step 4: Normalise the OrderDtoValidatorTests `Then` verbs**
+
+| From | To |
+|---|---|
+| `GivenOrderDto_WhenValid_ThenReturnNoError` | `GivenOrderDto_WhenValid_ThenHasNoErrors` |
+| `GivenOrderDto_WhenTitleEmpty_ThenReturnError` | `GivenOrderDto_WhenTitleEmpty_ThenHasErrorForTitle` |
+| `GivenOrderDto_WhenDescriptionNull_ThenReturnNoError` | `GivenOrderDto_WhenDescriptionNull_ThenHasNoErrorForDescription` |
+| `GivenOrderDto_WhenBuyerIdZero_ThenReturnError` | `GivenOrderDto_WhenBuyerIdZero_ThenHasErrorForBuyerId` |
+| `GivenOrderDto_WhenTotalNegative_ThenReturnError` | `GivenOrderDto_WhenTotalNegative_ThenHasErrorForTotal` |
+| `GivenOrderDto_WhenParticipantsNull_ThenReturnError` | `GivenOrderDto_WhenParticipantsNull_ThenHasErrorForParticipants` |
+| `GivenOrderDto_WhenParticipantsEmpty_ThenReturnError` | `GivenOrderDto_WhenParticipantsEmpty_ThenHasErrorForParticipants` |
+| `GivenOrderDto_WhenParticipantsContainsNull_ThenReturnError` | `GivenOrderDto_WhenParticipantsContainsNull_ThenHasErrorForParticipants` |
+| `GivenOrderDto_WhenParticipantsDuplicate_ThenReturnError` | `GivenOrderDto_WhenParticipantsDuplicate_ThenHasDuplicatedParticipantError` |
+
+- [ ] **Step 5: Verify no old-style names survive**
+
+```bash
+grep -rn "public.*Task\|public.*void" test/UnitTests --include=*Tests.cs | grep -v "Given" | grep -v "private" | grep -v "static"
+```
+
+Expected: no output (helper and factory methods are `private static` and therefore filtered out).
+
+- [ ] **Step 6: Run tests**
+
+```bash
+dotnet test test/UnitTests/MoneyGroup.UnitTests.csproj
+```
+
+Expected: PASS, `total: 36`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add test/UnitTests
+git commit -m "test: standardise on Given_When_Then naming
+
+Also corrects two names that contradicted their assertions:
+RemoveOrderAsync_OrderNotFound_ShouldThrowInvalidOperationException
+asserted Assert.False and never threw."
+```
+
+---
+
+### Task 10: Introduce test data builders
+
+**Files:**
+- Create: `test/UnitTests/Builders/OrderDtoBuilder.cs`
+- Create: `test/UnitTests/Builders/UserDtoBuilder.cs`
+- Modify: `test/UnitTests/WebApi/Validators/OrderDtoValidatorTests.cs`
+- Modify: `test/UnitTests/Core/Services/OrderServiceTests.cs`
+
+**Interfaces:**
+- Produces:
+  - `MoneyGroup.UnitTests.Builders.OrderDtoBuilder` — `static OrderDtoBuilder Valid()`, `WithTitle(string?)`, `WithDescription(string?)`, `WithTotal(decimal)`, `WithBuyer(int)`, `WithParticipants(params int[])`, `WithNoParticipants()`, `WithNullParticipants()`, `OrderDto Build()`
+  - `MoneyGroup.UnitTests.Builders.UserDtoBuilder` — `static UserDtoBuilder Valid()`, `WithId(int)`, `WithName(string)`, `WithEmail(string?)`, `UserDto Build()`
+
+- [ ] **Step 1: Write OrderDtoBuilder**
+
+Create `test/UnitTests/Builders/OrderDtoBuilder.cs`:
+
+```csharp
+using MoneyGroup.Core.Models.Orders;
+
+namespace MoneyGroup.UnitTests.Builders;
+
+/// <summary>
+/// Builds <see cref="OrderDto"/> instances for tests. <see cref="Valid"/> returns a
+/// dto that passes every OrderDtoValidator rule, so each test only states the one
+/// field it cares about.
+/// </summary>
+public sealed class OrderDtoBuilder
+{
+    private int _id;
+    private string _title = "Title";
+    private string? _description = "Description";
+    private decimal _total;
+    private int _buyerId = 1;
+    private IEnumerable<ParticipantDto> _participants = [new ParticipantDto { ParticipantId = 1 }];
+
+    public static OrderDtoBuilder Valid() => new();
+
+    public OrderDtoBuilder WithId(int id)
+    {
+        _id = id;
+        return this;
+    }
+
+    public OrderDtoBuilder WithTitle(string? title)
+    {
+        _title = title!;
+        return this;
+    }
+
+    public OrderDtoBuilder WithDescription(string? description)
+    {
+        _description = description;
+        return this;
+    }
+
+    public OrderDtoBuilder WithTotal(decimal total)
+    {
+        _total = total;
+        return this;
+    }
+
+    public OrderDtoBuilder WithBuyer(int buyerId)
+    {
+        _buyerId = buyerId;
+        return this;
+    }
+
+    public OrderDtoBuilder WithParticipants(params int[] participantIds)
+    {
+        _participants = participantIds.Select(id => new ParticipantDto { ParticipantId = id }).ToList();
+        return this;
+    }
+
+    public OrderDtoBuilder WithParticipants(IEnumerable<ParticipantDto> participants)
+    {
+        _participants = participants;
+        return this;
+    }
+
+    public OrderDtoBuilder WithNoParticipants()
+    {
+        _participants = [];
+        return this;
+    }
+
+    public OrderDtoBuilder WithNullParticipants()
+    {
+        _participants = null!;
+        return this;
+    }
+
+    public OrderDto Build() => new()
+    {
+        Id = _id,
+        Title = _title,
+        Description = _description,
+        Total = _total,
+        BuyerId = _buyerId,
+        Participants = _participants,
+    };
+}
+```
+
+- [ ] **Step 2: Write UserDtoBuilder**
+
+Create `test/UnitTests/Builders/UserDtoBuilder.cs`:
+
+```csharp
+using MoneyGroup.Core.Models.Users;
+
+namespace MoneyGroup.UnitTests.Builders;
+
+/// <summary>
+/// Builds <see cref="UserDto"/> instances for tests.
+/// </summary>
+public sealed class UserDtoBuilder
+{
+    private int _id = 1;
+    private string _name = "User";
+    private string? _email = "user@domain.com";
+
+    public static UserDtoBuilder Valid() => new();
+
+    public UserDtoBuilder WithId(int id)
+    {
+        _id = id;
+        return this;
+    }
+
+    public UserDtoBuilder WithName(string name)
+    {
+        _name = name;
+        return this;
+    }
+
+    public UserDtoBuilder WithEmail(string? email)
+    {
+        _email = email;
+        return this;
+    }
+
+    public UserDto Build() => new()
+    {
+        Id = _id,
+        Name = _name,
+        Email = _email,
+    };
+}
+```
+
+- [ ] **Step 3: Build to confirm the builders compile**
+
+```bash
+dotnet build test/UnitTests/MoneyGroup.UnitTests.csproj
+```
+
+Expected: build succeeds with no warnings (warnings are errors).
+
+- [ ] **Step 4: Adopt OrderDtoBuilder in OrderDtoValidatorTests**
+
+Add `using MoneyGroup.UnitTests.Builders;` and replace each inline `new OrderDto() { … }` arrangement. For example, `GivenOrderDto_WhenValid_ThenHasNoErrors` becomes:
+
+```csharp
+        // Arrange
+        var order = OrderDtoBuilder.Valid().Build();
+```
+
+and `GivenOrderDto_WhenParticipantsDuplicate_ThenHasDuplicatedParticipantError` becomes:
+
+```csharp
+        // Arrange
+        var order = OrderDtoBuilder.Valid().WithParticipants(1, 1).Build();
+```
+
+The remaining seven follow the same shape: `WithTitle("   ")`, `WithDescription(null)`, `WithBuyer(0)`, `WithTotal(-1)`, `WithNullParticipants()`, `WithNoParticipants()`, and for the contains-null case `WithParticipants([null!, null!])`.
+
+> Note the behavioural difference this exposes: the old tests constructed an `OrderDto` with *only* the field under test set, so unrelated rules also fired. Using `Valid()` means only the rule under test fires. `ShouldHaveValidationErrorFor` still passes, and the tests become genuinely single-purpose.
+
+- [ ] **Step 5: Adopt OrderDtoBuilder in OrderServiceTests**
+
+Replace the four inline `new OrderDto { … }` arrangements, e.g. in `GivenOrder_WhenBuyerAndParticipantsExist_ThenAddsOrder`:
+
+```csharp
+        var model = OrderDtoBuilder.Valid().WithBuyer(1).WithParticipants(2, 3).Build();
+```
+
+and in `GivenOrder_WhenNoParticipants_ThenAddsOrderWithoutCountingParticipants`:
+
+```csharp
+        var model = OrderDtoBuilder.Valid().WithBuyer(1).WithNoParticipants().Build();
+```
+
+- [ ] **Step 6: Run tests**
+
+```bash
+dotnet test test/UnitTests/MoneyGroup.UnitTests.csproj
+```
+
+Expected: PASS, `total: 36`.
+
+- [ ] **Step 7: Verify full-suite parity — Phase 2 gate**
+
+```bash
+docker exec -w /mssql-server-setup-scripts.d moneygroup-mssql-1 bash ./reset.sh
+dotnet test --solution MoneyGroup.slnx
+```
+
+Expected: `total: 63`, `failed: 0`, `skipped: 2`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add test/UnitTests/Builders test/UnitTests/Core test/UnitTests/WebApi
+git commit -m "test: introduce OrderDtoBuilder and UserDtoBuilder
+
+Collapses the duplicated inline DTO literals. Valid() returns an object
+that passes every validator rule, so each test states only the field it
+is about. Phase 2 complete: still 63 tests, no Moq, one naming
+convention."
+```
+
+---
+
+# Phase 3 — Close the unit-testable gaps
+
+Test count grows from 63 to roughly 103.
+
+---
+
+### Task 11: Test UserService
+
+**Files:**
+- Create: `test/UnitTests/Core/Services/UserServiceTests.cs`
+
+**Interfaces:**
+- Consumes: `UserDtoBuilder` from Task 10
+- Produces: 6 tests covering all three `UserService` methods.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/UnitTests/Core/Services/UserServiceTests.cs`:
+
+```csharp
+using MoneyGroup.Core.Abstractions;
+using MoneyGroup.Core.Entities;
+using MoneyGroup.Core.Models.Paginations;
+using MoneyGroup.Core.Models.Users;
+using MoneyGroup.Core.Services;
+using MoneyGroup.Core.Specifications;
+using MoneyGroup.UnitTests.Builders;
+
+using NSubstitute;
+
+namespace MoneyGroup.UnitTests.Core.Services;
+
+[Trait("Category", "Unit")]
+public class UserServiceTests
+{
+    private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
+    private readonly UserService _userService;
+
+    public UserServiceTests()
+    {
+        _userService = new UserService(_userRepository);
+    }
+
+    [Fact]
+    public async Task GivenUserId_WhenUserExists_ThenReturnsUser()
+    {
+        // Arrange
+        var user = UserDtoBuilder.Valid().WithId(7).Build();
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        _userRepository.FirstOrDefaultAsync<UserDto>(Arg.Any<EntityByIdSpec<User>>(), cancellationToken)
+            .Returns(user);
+
+        // Act
+        var result = await _userService.GetUserByIdAsync(7, cancellationToken);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(7, result.Id);
+        await _userRepository.Received(1)
+            .FirstOrDefaultAsync<UserDto>(Arg.Any<EntityByIdSpec<User>>(), cancellationToken);
+    }
+
+    [Fact]
+    public async Task GivenUserId_WhenUserMissing_ThenReturnsNull()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        _userRepository.FirstOrDefaultAsync<UserDto>(Arg.Any<EntityByIdSpec<User>>(), cancellationToken)
+            .Returns((UserDto?)null);
+
+        // Act
+        var result = await _userService.GetUserByIdAsync(int.MaxValue, cancellationToken);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GivenEmail_WhenUserExists_ThenReturnsUser()
+    {
+        // Arrange
+        var user = UserDtoBuilder.Valid().WithEmail("known@domain.com").Build();
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        _userRepository.FirstOrDefaultAsync<UserDto>(Arg.Any<UserByEmailSpec>(), cancellationToken)
+            .Returns(user);
+
+        // Act
+        var result = await _userService.GetUserByEmailAsync("known@domain.com", cancellationToken);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("known@domain.com", result.Email);
+        await _userRepository.Received(1)
+            .FirstOrDefaultAsync<UserDto>(Arg.Any<UserByEmailSpec>(), cancellationToken);
+    }
+
+    [Fact]
+    public async Task GivenEmail_WhenUserMissing_ThenReturnsNull()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        _userRepository.FirstOrDefaultAsync<UserDto>(Arg.Any<UserByEmailSpec>(), cancellationToken)
+            .Returns((UserDto?)null);
+
+        // Act
+        var result = await _userService.GetUserByEmailAsync("absent@domain.com", cancellationToken);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GivenPagingOptions_WhenUsersExist_ThenReturnsPaginatedUsers()
+    {
+        // Arrange
+        var options = new UserPaginatedOptions(page: 1, size: 10);
+        var expected = new PaginatedModel<UserDto>
+        {
+            Page = 1,
+            Count = 1,
+            Total = 1,
+            Items = [UserDtoBuilder.Valid().Build()],
+        };
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        _userRepository.GetByPageAsync<UserDto>(Arg.Any<UserPaginatedSpec>(), cancellationToken)
+            .Returns(expected);
+
+        // Act
+        var result = await _userService.GetUsersByPageAsync(options, cancellationToken);
+
+        // Assert
+        Assert.Same(expected, result);
+        await _userRepository.Received(1)
+            .GetByPageAsync<UserDto>(Arg.Any<UserPaginatedSpec>(), cancellationToken);
+    }
+
+    [Fact]
+    public async Task GivenPagingOptions_WhenKeywordSupplied_ThenPassesSpecificationBuiltFromOptions()
+    {
+        // Arrange
+        var options = new UserPaginatedOptions(page: 2, size: 5) { Keyword = "ruong" };
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        _userRepository.GetByPageAsync<UserDto>(Arg.Any<UserPaginatedSpec>(), cancellationToken)
+            .Returns(new PaginatedModel<UserDto> { Page = 2, Count = 0, Total = 0, Items = [] });
+
+        // Act
+        await _userService.GetUsersByPageAsync(options, cancellationToken);
+
+        // Assert
+        await _userRepository.Received(1).GetByPageAsync<UserDto>(
+            Arg.Is<UserPaginatedSpec>(spec =>
+                spec.PaginatedOptions.Page == 2 && spec.PaginatedOptions.Size == 5),
+            cancellationToken);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify they pass**
+
+```bash
+dotnet test test/UnitTests/MoneyGroup.UnitTests.csproj
+```
+
+Expected: PASS, `total: 42`.
+
+These tests describe existing behaviour, so they pass immediately — that is expected for characterisation tests of untested code. If any fails, the failure is a real defect: investigate before continuing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/UnitTests/Core/Services/UserServiceTests.cs
+git commit -m "test: add UserService unit tests
+
+Covers all three methods, including GetUserByEmailAsync which was
+previously unreachable in tests because functional tests bypass
+authorization."
+```
+
+---
+
+### Task 12: Test the specifications
+
+**Files:**
+- Create: `test/UnitTests/Core/Specifications/SpecificationTests.cs`
+
+**Interfaces:**
+- Consumes: nothing new
+- Produces: 14 tests. Uses `Specification<T>.Evaluate(IEnumerable<T>)` and `IsSatisfiedBy(T)` — both verified present on Ardalis.Specification 9.3.1.
+
+- [ ] **Step 1: Write the tests**
+
+Create `test/UnitTests/Core/Specifications/SpecificationTests.cs`:
+
+```csharp
+using MoneyGroup.Core.Entities;
+using MoneyGroup.Core.Models.Orders;
+using MoneyGroup.Core.Models.Paginations;
+using MoneyGroup.Core.Models.Users;
+using MoneyGroup.Core.Specifications;
+
+namespace MoneyGroup.UnitTests.Core.Specifications;
+
+[Trait("Category", "Unit")]
+public class SpecificationTests
+{
+    private static Order Order(int id, int buyerId = 1, decimal total = 100, params int[] participantIds) => new()
+    {
+        Id = id,
+        Title = $"Order {id}",
+        BuyerId = buyerId,
+        Total = total,
+        Participants = [.. participantIds.Select(p => new OrderParticipant { ParticipantId = p, OrderId = id })],
+    };
+
+    [Fact]
+    public void GivenEntityByIdSpec_WhenIdMatches_ThenIsSatisfied()
+    {
+        var spec = new EntityByIdSpec<Order>(5);
+
+        Assert.True(spec.IsSatisfiedBy(Order(5)));
+        Assert.False(spec.IsSatisfiedBy(Order(6)));
+    }
+
+    [Fact]
+    public void GivenEntityByIdsSpec_WhenIdInSet_ThenIsSatisfied()
+    {
+        var spec = new EntityByIdsSpec<User>([1, 3]);
+
+        Assert.True(spec.IsSatisfiedBy(new User { Id = 1, Name = "A" }));
+        Assert.True(spec.IsSatisfiedBy(new User { Id = 3, Name = "C" }));
+        Assert.False(spec.IsSatisfiedBy(new User { Id = 2, Name = "B" }));
+    }
+
+    [Fact]
+    public void GivenEntityByIdsSpec_WhenIdsEmpty_ThenNothingIsSatisfied()
+    {
+        var spec = new EntityByIdsSpec<User>([]);
+
+        Assert.False(spec.IsSatisfiedBy(new User { Id = 1, Name = "A" }));
+    }
+
+    [Fact]
+    public void GivenUserByEmailSpec_WhenEmailMatches_ThenIsSatisfied()
+    {
+        var spec = new UserByEmailSpec("a@b.com");
+
+        Assert.True(spec.IsSatisfiedBy(new User { Id = 1, Name = "A", Email = "a@b.com" }));
+        Assert.False(spec.IsSatisfiedBy(new User { Id = 2, Name = "B", Email = "other@b.com" }));
+        Assert.False(spec.IsSatisfiedBy(new User { Id = 3, Name = "C", Email = null }));
+    }
+
+    [Fact]
+    public void GivenBasePaginatedSpec_WhenFirstPage_ThenSkipsNoneAndTakesPageSize()
+    {
+        var spec = new BasePaginatedSpecification<User>(new PaginatedOptions(page: 1, size: 3));
+
+        Assert.Equal(0, spec.Skip);
+        Assert.Equal(3, spec.Take);
+    }
+
+    [Fact]
+    public void GivenBasePaginatedSpec_WhenThirdPage_ThenSkipsTwoPages()
+    {
+        var spec = new BasePaginatedSpecification<User>(new PaginatedOptions(page: 3, size: 10));
+
+        Assert.Equal(20, spec.Skip);
+        Assert.Equal(10, spec.Take);
+    }
+
+    [Fact]
+    public void GivenBasePaginatedSpec_WhenEvaluated_ThenReturnsRequestedWindow()
+    {
+        var users = Enumerable.Range(1, 10)
+            .Select(i => new User { Id = i, Name = $"U{i}" })
+            .ToList();
+        var spec = new BasePaginatedSpecification<User>(new PaginatedOptions(page: 2, size: 3));
+
+        var result = spec.Evaluate(users).ToList();
+
+        Assert.Equal(3, result.Count);
+        Assert.Equal([4, 5, 6], result.Select(u => u.Id));
+    }
+
+    [Fact]
+    public void GivenUserPaginatedSpec_WhenKeywordSupplied_ThenFiltersByNameContains()
+    {
+        var users = new List<User>
+        {
+            new() { Id = 1, Name = "Truong" },
+            new() { Id = 2, Name = "Duc" },
+            new() { Id = 3, Name = "Manh" },
+        };
+        var spec = new UserPaginatedSpec(new UserPaginatedOptions(1, 10) { Keyword = "ruo" });
+
+        var result = spec.Evaluate(users).ToList();
+
+        Assert.Equal([1], result.Select(u => u.Id));
+    }
+
+    [Fact]
+    public void GivenUserPaginatedSpec_WhenKeywordBlank_ThenReturnsEveryone()
+    {
+        var users = new List<User>
+        {
+            new() { Id = 1, Name = "Truong" },
+            new() { Id = 2, Name = "Duc" },
+        };
+        var spec = new UserPaginatedSpec(new UserPaginatedOptions(1, 10) { Keyword = "   " });
+
+        var result = spec.Evaluate(users).ToList();
+
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public void GivenOrderPaginatedSpec_WhenNoFilters_ThenOrdersByIdDescending()
+    {
+        var orders = new List<Order> { Order(1), Order(3), Order(2) };
+        var spec = new OrderPaginatedSpec(new OrderPaginatedOptions(null, null, null, null, 1, 10));
+
+        var result = spec.Evaluate(orders).ToList();
+
+        Assert.Equal([3, 2, 1], result.Select(o => o.Id));
+    }
+
+    [Fact]
+    public void GivenOrderPaginatedSpec_WhenBuyerIdSupplied_ThenFiltersByBuyer()
+    {
+        var orders = new List<Order> { Order(1, buyerId: 1), Order(2, buyerId: 2) };
+        var spec = new OrderPaginatedSpec(new OrderPaginatedOptions(2, null, null, null, 1, 10));
+
+        var result = spec.Evaluate(orders).ToList();
+
+        Assert.Equal([2], result.Select(o => o.Id));
+    }
+
+    [Fact]
+    public void GivenOrderPaginatedSpec_WhenParticipantIdSupplied_ThenFiltersByParticipant()
+    {
+        var orders = new List<Order>
+        {
+            Order(1, participantIds: [1, 2]),
+            Order(2, participantIds: [3]),
+        };
+        var spec = new OrderPaginatedSpec(new OrderPaginatedOptions(null, 3, null, null, 1, 10));
+
+        var result = spec.Evaluate(orders).ToList();
+
+        Assert.Equal([2], result.Select(o => o.Id));
+    }
+
+    [Fact]
+    public void GivenOrderPaginatedSpec_WhenTotalBoundsSupplied_ThenFiltersInclusively()
+    {
+        var orders = new List<Order>
+        {
+            Order(1, total: 50),
+            Order(2, total: 100),
+            Order(3, total: 150),
+        };
+        var spec = new OrderPaginatedSpec(new OrderPaginatedOptions(null, null, 150m, 100m, 1, 10));
+
+        var result = spec.Evaluate(orders).ToList();
+
+        Assert.Equal([3, 2], result.Select(o => o.Id));
+    }
+
+    [Fact]
+    public void GivenOrderPaginatedSpec_WhenAllFiltersCombined_ThenAppliesEveryFilter()
+    {
+        var orders = new List<Order>
+        {
+            Order(1, buyerId: 1, total: 100, participantIds: [1]),
+            Order(2, buyerId: 1, total: 500, participantIds: [1]),
+            Order(3, buyerId: 2, total: 100, participantIds: [1]),
+            Order(4, buyerId: 1, total: 100, participantIds: [9]),
+        };
+        var spec = new OrderPaginatedSpec(new OrderPaginatedOptions(1, 1, 200m, 50m, 1, 10));
+
+        var result = spec.Evaluate(orders).ToList();
+
+        Assert.Equal([1], result.Select(o => o.Id));
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+dotnet test test/UnitTests/MoneyGroup.UnitTests.csproj
+```
+
+Expected: PASS, `total: 56`.
+
+`Evaluate(IEnumerable<T>)` applies `Skip`/`Take`: `Ardalis.Specification.PaginationEvaluator` implements `IInMemoryEvaluator`, verified by reflection against the 9.3.1 assembly. `WhereEvaluator` and `OrderEvaluator` do too, which is what makes the filter and ordering assertions valid in-memory.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/UnitTests/Core/Specifications/SpecificationTests.cs
+git commit -m "test: add specification unit tests
+
+Covers all six specifications, including OrderPaginatedSpec's filter
+combinations and ordering, which were previously exercised only
+indirectly through repository integration tests."
+```
+
+---
+
+### Task 13: Test the Mapperly mapper
+
+**Files:**
+- Create: `test/UnitTests/Infrastructure/Mapperly/MapperTests.cs`
+
+**Interfaces:**
+- Consumes: nothing new
+- Produces: 6 tests over `MoneyGroup.Infrastructure.Mapperly.Mapper`.
+
+> These contribute no coverage — Mapperly's generated code carries `[GeneratedCode]`. They are still the highest-value tests in this phase: a generated mapper silently dropping a property is exactly the failure a functional test's `Assert.NotNull` cannot catch.
+
+- [ ] **Step 1: Write the tests**
+
+Create `test/UnitTests/Infrastructure/Mapperly/MapperTests.cs`:
+
+```csharp
+using MoneyGroup.Core.Entities;
+using MoneyGroup.Core.Models.Orders;
+using MoneyGroup.Core.Models.Users;
+using MoneyGroup.Infrastructure.Mapperly;
+using MoneyGroup.UnitTests.Builders;
+
+namespace MoneyGroup.UnitTests.Infrastructure.Mapperly;
+
+[Trait("Category", "Unit")]
+public class MapperTests
+{
+    private readonly Mapper _mapper = new();
+
+    [Fact]
+    public void GivenParticipantDto_WhenMapped_ThenCopiesParticipantId()
+    {
+        // Arrange
+        var dto = new ParticipantDto { ParticipantId = 42 };
+
+        // Act
+        var entity = _mapper.Map(dto);
+
+        // Assert
+        Assert.Equal(42, entity.ParticipantId);
+    }
+
+    [Fact]
+    public void GivenOrderDto_WhenMapped_ThenCopiesEveryScalarField()
+    {
+        // Arrange
+        var dto = OrderDtoBuilder.Valid()
+            .WithId(7)
+            .WithTitle("Dinner")
+            .WithDescription("Team dinner")
+            .WithTotal(1234.56m)
+            .WithBuyer(3)
+            .WithParticipants(1, 2)
+            .Build();
+
+        // Act
+        var entity = _mapper.Map(dto);
+
+        // Assert
+        Assert.Equal(7, entity.Id);
+        Assert.Equal("Dinner", entity.Title);
+        Assert.Equal("Team dinner", entity.Description);
+        Assert.Equal(1234.56m, entity.Total);
+        Assert.Equal(3, entity.BuyerId);
+        Assert.Equal([1, 2], entity.Participants.Select(p => p.ParticipantId));
+    }
+
+    [Fact]
+    public void GivenOrderDto_WhenMapped_ThenLeavesBuyerNavigationUnset()
+    {
+        // Arrange
+        var dto = OrderDtoBuilder.Valid().WithBuyer(3).Build();
+
+        // Act
+        var entity = _mapper.Map(dto);
+
+        // Assert
+        Assert.Null(entity.Buyer);
+    }
+
+    [Fact]
+    public void GivenOrderParticipant_WhenMapped_ThenFlattensParticipantName()
+    {
+        // Arrange
+        var entity = new OrderParticipant
+        {
+            ParticipantId = 5,
+            Participant = new User { Id = 5, Name = "Manh" },
+        };
+
+        // Act
+        var dto = _mapper.Map(entity);
+
+        // Assert
+        Assert.Equal(5, dto.ParticipantId);
+        Assert.Equal("Manh", dto.ParticipantName);
+    }
+
+    [Fact]
+    public void GivenOrder_WhenMapped_ThenFlattensBuyerName()
+    {
+        // Arrange
+        var entity = new Order
+        {
+            Id = 1,
+            Title = "Order 1",
+            Description = "desc",
+            Total = 10_000m,
+            BuyerId = 1,
+            Buyer = new User { Id = 1, Name = "Truong" },
+            Participants =
+            [
+                new() { ParticipantId = 2, Participant = new User { Id = 2, Name = "Duc" } },
+            ],
+        };
+
+        // Act
+        var dto = _mapper.Map(entity);
+
+        // Assert
+        Assert.Equal(1, dto.Id);
+        Assert.Equal("Order 1", dto.Title);
+        Assert.Equal(10_000m, dto.Total);
+        Assert.Equal("Truong", dto.BuyerName);
+        var participant = Assert.Single(dto.Participants);
+        Assert.Equal(2, participant.ParticipantId);
+        Assert.Equal("Duc", participant.ParticipantName);
+    }
+
+    [Fact]
+    public void GivenUserQueryable_WhenProjected_ThenMapsIdNameAndEmail()
+    {
+        // Arrange
+        var users = new List<User>
+        {
+            new() { Id = 1, Name = "Truong", Email = "t@d.com" },
+            new() { Id = 2, Name = "Duc", Email = null },
+        }.AsQueryable();
+
+        // Act
+        var projected = _mapper.Project(users).ToList();
+
+        // Assert
+        Assert.Equal(2, projected.Count);
+        Assert.Equal([1, 2], projected.Select(u => u.Id));
+        Assert.Equal(["Truong", "Duc"], projected.Select(u => u.Name));
+        Assert.Equal("t@d.com", projected[0].Email);
+        Assert.Null(projected[1].Email);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+dotnet test test/UnitTests/MoneyGroup.UnitTests.csproj
+```
+
+Expected: PASS, `total: 62`.
+
+`GivenOrderDto_WhenMapped_ThenLeavesBuyerNavigationUnset` asserts `Assert.Null(entity.Buyer)` even though `Order.Buyer` is declared `= null!`. The `[MapperIgnoreTarget(nameof(Order.Buyer))]` attribute means Mapperly never assigns it, so it stays null at runtime. If this fails, Mapperly's ignore is not doing what the attribute claims — a real finding worth reporting.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/UnitTests/Infrastructure/Mapperly/MapperTests.cs
+git commit -m "test: add Mapperly mapper unit tests
+
+Pins the entity/DTO boundary, including the BuyerName and
+ParticipantName flattening and the ignored Buyer navigation. Adds no
+coverage (generated code is attributed [GeneratedCode]) but catches
+silent property drops that functional assertions cannot."
+```
+
+---
+
+### Task 14: Test BusinessValidationExceptionHandler
+
+**Files:**
+- Create: `test/UnitTests/WebApi/Middlewares/BusinessValidationExceptionHandlerTests.cs`
+
+**Interfaces:**
+- Produces: 4 tests over `BusinessValidationExceptionHandler.TryHandleAsync`.
+
+- [ ] **Step 1: Write the tests**
+
+Create `test/UnitTests/WebApi/Middlewares/BusinessValidationExceptionHandlerTests.cs`:
+
+```csharp
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+using MoneyGroup.Core.Exceptions;
+using MoneyGroup.WebApi.Middlewares;
+
+using NSubstitute;
+
+namespace MoneyGroup.UnitTests.WebApi.Middlewares;
+
+[Trait("Category", "Unit")]
+public class BusinessValidationExceptionHandlerTests
+{
+    private readonly IProblemDetailsService _problemDetailsService = Substitute.For<IProblemDetailsService>();
+    private readonly BusinessValidationExceptionHandler _handler;
+
+    public BusinessValidationExceptionHandlerTests()
+    {
+        _handler = new BusinessValidationExceptionHandler(_problemDetailsService);
+    }
+
+    [Fact]
+    public async Task GivenUnrelatedException_WhenHandled_ThenReturnsFalseAndWritesNothing()
+    {
+        // Arrange
+        var httpContext = new DefaultHttpContext();
+
+        // Act
+        var handled = await _handler.TryHandleAsync(
+            httpContext, new InvalidOperationException("boom"), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(handled);
+        await _problemDetailsService.DidNotReceive().WriteAsync(Arg.Any<ProblemDetailsContext>());
+    }
+
+    [Fact]
+    public async Task GivenBuyerNotFound_WhenHandled_ThenReturnsTrue()
+    {
+        // Arrange
+        var httpContext = new DefaultHttpContext();
+
+        // Act
+        var handled = await _handler.TryHandleAsync(
+            httpContext, new BuyerNotFoundException(), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.True(handled);
+    }
+
+    [Fact]
+    public async Task GivenBuyerNotFound_WhenHandled_ThenSetsBadRequestStatus()
+    {
+        // Arrange
+        var httpContext = new DefaultHttpContext();
+
+        // Act
+        await _handler.TryHandleAsync(
+            httpContext, new BuyerNotFoundException(), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, httpContext.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GivenParticipantNotFound_WhenHandled_ThenWritesProblemDetailsCarryingTheMessage()
+    {
+        // Arrange
+        var httpContext = new DefaultHttpContext();
+        var exception = new ParticipantNotFoundException();
+
+        // Act
+        await _handler.TryHandleAsync(httpContext, exception, TestContext.Current.CancellationToken);
+
+        // Assert
+        await _problemDetailsService.Received(1).WriteAsync(
+            Arg.Is<ProblemDetailsContext>(ctx =>
+                ctx.HttpContext == httpContext
+                && ctx.Exception == exception
+                && ctx.ProblemDetails.Detail == "Participant not found"));
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+dotnet test test/UnitTests/MoneyGroup.UnitTests.csproj
+```
+
+Expected: PASS, `total: 66`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/UnitTests/WebApi/Middlewares/BusinessValidationExceptionHandlerTests.cs
+git commit -m "test: add BusinessValidationExceptionHandler unit tests
+
+Covers the non-business-exception passthrough, the 400 status, and that
+the exception message reaches ProblemDetails.Detail."
+```
+
+---
+
+### Task 15: Test OrderService.GetOrdersByPageAsync
+
+**Files:**
+- Modify: `test/UnitTests/Core/Services/OrderServiceTests.cs`
+
+**Interfaces:**
+- Produces: 2 additional tests on the existing class.
+
+- [ ] **Step 1: Add the tests**
+
+Append these two methods to `OrderServiceTests`, and add `using MoneyGroup.Core.Models.Paginations;` to the file's usings:
+
+```csharp
+    [Fact]
+    public async Task GivenPagingOptions_WhenOrdersExist_ThenReturnsPaginatedOrders()
+    {
+        // Arrange
+        var options = new OrderPaginatedOptions(null, null, null, null, 1, 10);
+        var expected = new PaginatedModel<OrderDetailedDto>
+        {
+            Page = 1,
+            Count = 1,
+            Total = 1,
+            Items = [new OrderDetailedDto { Id = 1, Title = "Order 1" }],
+        };
+
+        _orderRepository.GetByPageAsync<OrderDetailedDto>(Arg.Any<OrderPaginatedSpec>(), Arg.Any<CancellationToken>())
+            .Returns(expected);
+
+        // Act
+        var result = await _orderService.GetOrdersByPageAsync(options);
+
+        // Assert
+        Assert.Same(expected, result);
+    }
+
+    [Fact]
+    public async Task GivenPagingOptions_WhenCalled_ThenPassesSpecificationBuiltFromOptions()
+    {
+        // Arrange
+        var options = new OrderPaginatedOptions(buyerId: 4, null, null, null, page: 3, size: 7);
+
+        _orderRepository.GetByPageAsync<OrderDetailedDto>(Arg.Any<OrderPaginatedSpec>(), Arg.Any<CancellationToken>())
+            .Returns(new PaginatedModel<OrderDetailedDto> { Page = 3, Count = 0, Total = 0, Items = [] });
+
+        // Act
+        await _orderService.GetOrdersByPageAsync(options);
+
+        // Assert
+        await _orderRepository.Received(1).GetByPageAsync<OrderDetailedDto>(
+            Arg.Is<OrderPaginatedSpec>(spec => spec.Skip == 14 && spec.Take == 7),
+            Arg.Any<CancellationToken>());
+    }
+```
+
+`Skip == 14` is `(3 − 1) × 7`, from `BasePaginatedSpecification`.
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+dotnet test test/UnitTests/MoneyGroup.UnitTests.csproj
+```
+
+Expected: PASS, `total: 68`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/UnitTests/Core/Services/OrderServiceTests.cs
+git commit -m "test: cover OrderService.GetOrdersByPageAsync
+
+The only OrderService method with no unit test. Asserts the paging
+specification is built from the supplied options."
+```
+
+---
+
+### Task 16: Make endpoint handlers testable
+
+**Files:**
+- Modify: `src/WebApi/Endpoints/OrderEndpoints.cs`
+- Modify: `src/WebApi/Endpoints/UserEndpoints.cs`
+- Modify: `src/WebApi/MoneyGroup.WebApi.csproj`
+
+**Interfaces:**
+- Produces: all 7 handlers become `internal static`, callable from `MoneyGroup.UnitTests`:
+  - `OrderEndpoints.GetOrdersAsync(OrderPaginatedRequest, IOrderService)` → `Task<Results<Ok<PaginatedModel<OrderDetailedDto>>, ValidationProblem>>`
+  - `OrderEndpoints.GetOrderByIdAsync(int, IOrderService)` → `Task<Results<Ok<OrderDetailedDto>, NotFound>>`
+  - `OrderEndpoints.CreateOrderAsync(OrderDto, IOrderService)` → `Task<Results<CreatedAtRoute<OrderDto>, ValidationProblem>>`
+  - `OrderEndpoints.DeleteOrderAsync(int, IOrderService, CancellationToken)` → `Task<Results<NoContent, NotFound>>`
+  - `UserEndpoints.GetUsersAsync(UserPaginatedRequest, IUserService)` → `Task<Results<Ok<PaginatedModel<UserDto>>, ValidationProblem>>`
+  - `UserEndpoints.GetUserByIdAsync(int, IUserService, CancellationToken)` → `Task<Results<Ok<UserDto>, NotFound>>`
+  - `UserEndpoints.GetExecutingUser(HttpContext)` → `Ok<UserDto>`
+
+**This is the only production-code change in the entire plan.**
+
+- [ ] **Step 1: Normalise OrderEndpoints handler accessibility**
+
+In `src/WebApi/Endpoints/OrderEndpoints.cs`, change all four handler declarations to `internal static`:
+
+```csharp
+    internal static async Task<Results<Ok<PaginatedModel<OrderDetailedDto>>, ValidationProblem>> GetOrdersAsync([AsParameters] OrderPaginatedRequest request, [FromServices] IOrderService orderService)
+```
+
+```csharp
+    internal static async Task<Results<CreatedAtRoute<OrderDto>, ValidationProblem>> CreateOrderAsync(OrderDto input, IOrderService orderService)
+```
+
+```csharp
+    internal static async Task<Results<NoContent, NotFound>> DeleteOrderAsync(int id, IOrderService orderService, CancellationToken cancellationToken)
+```
+
+```csharp
+    internal static async Task<Results<Ok<OrderDetailedDto>, NotFound>> GetOrderByIdAsync(int id, IOrderService orderService)
+```
+
+The last one was `public static` — the inconsistency this step removes.
+
+- [ ] **Step 2: Normalise UserEndpoints handler accessibility**
+
+In `src/WebApi/Endpoints/UserEndpoints.cs`:
+
+```csharp
+    internal static async Task<Results<Ok<PaginatedModel<UserDto>>, ValidationProblem>> GetUsersAsync([AsParameters] UserPaginatedRequest request, [FromServices] IUserService userService)
+```
+
+```csharp
+    internal static async Task<Results<Ok<UserDto>, NotFound>> GetUserByIdAsync(int id, [FromServices] IUserService userService, CancellationToken cancellationToken)
+```
+
+```csharp
+    internal static Ok<UserDto> GetExecutingUser(HttpContext httpContext)
+```
+
+- [ ] **Step 3: Grant UnitTests access to internals**
+
+In `src/WebApi/MoneyGroup.WebApi.csproj`, add to the item group that already contains the `InternalsVisibleTo` entry:
+
+```xml
+    <InternalsVisibleTo Include="MoneyGroup.UnitTests" />
+```
+
+so it reads:
+
+```xml
+    <InternalsVisibleTo Include="MoneyGroup.FunctionalTests" />
+    <InternalsVisibleTo Include="MoneyGroup.UnitTests" />
+```
+
+- [ ] **Step 4: Verify the application still builds and routes**
+
+```bash
+dotnet build MoneyGroup.slnx
+```
+
+Expected: build succeeds. Minimal-API endpoint registration uses method-group references inside the same class, so accessibility changes do not affect routing.
+
+- [ ] **Step 5: Verify the full suite still passes**
+
+```bash
+docker exec -w /mssql-server-setup-scripts.d moneygroup-mssql-1 bash ./reset.sh
+dotnet test --solution MoneyGroup.slnx
+```
+
+Expected: `failed: 0`. Functional endpoint tests confirm routing is unaffected.
+
+- [ ] **Step 6: Discard the regenerated OpenAPI document if it appears**
+
+```bash
+git status --short src/WebApi/MoneyGroup.WebApi.json
+```
+
+If listed, confirm it is line-endings only and discard it:
+
+```bash
+git diff --numstat src/WebApi/MoneyGroup.WebApi.json
+git checkout -- src/WebApi/MoneyGroup.WebApi.json
+```
+
+Empty `--numstat` output means no content changed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/WebApi/Endpoints/OrderEndpoints.cs src/WebApi/Endpoints/UserEndpoints.cs src/WebApi/MoneyGroup.WebApi.csproj
+git commit -m "refactor(api): make endpoint handlers internal for unit testing
+
+Normalises all seven handlers to 'internal static', removing the
+existing inconsistency where GetOrderByIdAsync and GetUserByIdAsync were
+public while their siblings were private. Extends the InternalsVisibleTo
+pattern already used for FunctionalTests and IntegrationTests."
+```
+
+---
+
+### Task 17: Test the endpoint handlers
+
+**Files:**
+- Create: `test/UnitTests/WebApi/Endpoints/OrderEndpointsTests.cs`
+- Create: `test/UnitTests/WebApi/Endpoints/UserEndpointsTests.cs`
+
+**Interfaces:**
+- Consumes: the `internal static` handlers from Task 16, `OrderDtoBuilder` and `UserDtoBuilder` from Task 10
+- Produces: 11 tests.
+
+- [ ] **Step 1: Write OrderEndpointsTests**
+
+Create `test/UnitTests/WebApi/Endpoints/OrderEndpointsTests.cs`:
+
+```csharp
+using Microsoft.AspNetCore.Http.HttpResults;
+
+using MoneyGroup.Core.Abstractions;
+using MoneyGroup.Core.Models.Orders;
+using MoneyGroup.Core.Models.Paginations;
+using MoneyGroup.UnitTests.Builders;
+using MoneyGroup.WebApi.Endpoints;
+
+using NSubstitute;
+
+namespace MoneyGroup.UnitTests.WebApi.Endpoints;
+
+[Trait("Category", "Unit")]
+public class OrderEndpointsTests
+{
+    private readonly IOrderService _orderService = Substitute.For<IOrderService>();
+
+    [Fact]
+    public async Task GivenOrderId_WhenOrderExists_ThenReturnsOk()
+    {
+        // Arrange
+        var order = new OrderDetailedDto { Id = 1, Title = "Order 1" };
+        _orderService.GetOrderByIdAsync(1, Arg.Any<CancellationToken>()).Returns(order);
+
+        // Act
+        var result = await OrderEndpoints.GetOrderByIdAsync(1, _orderService);
+
+        // Assert
+        var ok = Assert.IsType<Ok<OrderDetailedDto>>(result.Result);
+        Assert.Same(order, ok.Value);
+    }
+
+    [Fact]
+    public async Task GivenOrderId_WhenOrderMissing_ThenReturnsNotFound()
+    {
+        // Arrange
+        _orderService.GetOrderByIdAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns((OrderDetailedDto?)null);
+
+        // Act
+        var result = await OrderEndpoints.GetOrderByIdAsync(int.MaxValue, _orderService);
+
+        // Assert
+        Assert.IsType<NotFound>(result.Result);
+    }
+
+    [Fact]
+    public async Task GivenOrderId_WhenOrderRemoved_ThenReturnsNoContent()
+    {
+        // Arrange
+        _orderService.RemoveOrderAsync(1, Arg.Any<CancellationToken>()).Returns(true);
+
+        // Act
+        var result = await OrderEndpoints.DeleteOrderAsync(1, _orderService, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.IsType<NoContent>(result.Result);
+    }
+
+    [Fact]
+    public async Task GivenOrderId_WhenNothingRemoved_ThenReturnsNotFound()
+    {
+        // Arrange
+        _orderService.RemoveOrderAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(false);
+
+        // Act
+        var result = await OrderEndpoints.DeleteOrderAsync(
+            int.MaxValue, _orderService, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.IsType<NotFound>(result.Result);
+    }
+
+    [Fact]
+    public async Task GivenOrder_WhenCreated_ThenReturnsCreatedAtRouteWithNewId()
+    {
+        // Arrange
+        var input = OrderDtoBuilder.Valid().WithBuyer(1).WithParticipants(1, 2).Build();
+        _orderService
+            .When(s => s.CreateOrderAsync(input, Arg.Any<CancellationToken>()))
+            .Do(_ => input.Id = 99);
+
+        // Act
+        var result = await OrderEndpoints.CreateOrderAsync(input, _orderService);
+
+        // Assert
+        var created = Assert.IsType<CreatedAtRoute<OrderDto>>(result.Result);
+        Assert.Same(input, created.Value);
+        Assert.Equal("GetOrderById", created.RouteName);
+        Assert.Equal(99, created.RouteValues["id"]);
+    }
+
+    [Fact]
+    public async Task GivenPagingRequest_WhenCalled_ThenReturnsOkWithServiceResult()
+    {
+        // Arrange
+        var request = new OrderPaginatedRequest(null, null, null, null, 1, 10);
+        var expected = new PaginatedModel<OrderDetailedDto>
+        {
+            Page = 1,
+            Count = 0,
+            Total = 0,
+            Items = [],
+        };
+        _orderService.GetOrdersByPageAsync(request).Returns(expected);
+
+        // Act
+        var result = await OrderEndpoints.GetOrdersAsync(request, _orderService);
+
+        // Assert
+        var ok = Assert.IsType<Ok<PaginatedModel<OrderDetailedDto>>>(result.Result);
+        Assert.Same(expected, ok.Value);
+    }
+}
+```
+
+- [ ] **Step 2: Write UserEndpointsTests**
+
+Create `test/UnitTests/WebApi/Endpoints/UserEndpointsTests.cs`:
+
+```csharp
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+using MoneyGroup.Core.Abstractions;
+using MoneyGroup.Core.Models.Paginations;
+using MoneyGroup.Core.Models.Users;
+using MoneyGroup.UnitTests.Builders;
+using MoneyGroup.WebApi.Endpoints;
+using MoneyGroup.WebApi.Features;
+
+using NSubstitute;
+
+namespace MoneyGroup.UnitTests.WebApi.Endpoints;
+
+[Trait("Category", "Unit")]
+public class UserEndpointsTests
+{
+    private readonly IUserService _userService = Substitute.For<IUserService>();
+
+    [Fact]
+    public async Task GivenUserId_WhenUserExists_ThenReturnsOk()
+    {
+        // Arrange
+        var user = UserDtoBuilder.Valid().WithId(1).Build();
+        _userService.GetUserByIdAsync(1, Arg.Any<CancellationToken>()).Returns(user);
+
+        // Act
+        var result = await UserEndpoints.GetUserByIdAsync(
+            1, _userService, TestContext.Current.CancellationToken);
+
+        // Assert
+        var ok = Assert.IsType<Ok<UserDto>>(result.Result);
+        Assert.Same(user, ok.Value);
+    }
+
+    [Fact]
+    public async Task GivenUserId_WhenUserMissing_ThenReturnsNotFound()
+    {
+        // Arrange
+        _userService.GetUserByIdAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns((UserDto?)null);
+
+        // Act
+        var result = await UserEndpoints.GetUserByIdAsync(
+            int.MaxValue, _userService, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.IsType<NotFound>(result.Result);
+    }
+
+    [Fact]
+    public async Task GivenPagingRequest_WhenCalled_ThenReturnsOkWithServiceResult()
+    {
+        // Arrange
+        var request = new UserPaginatedRequest(keyword: null, page: 1, size: 10);
+        var expected = new PaginatedModel<UserDto> { Page = 1, Count = 0, Total = 0, Items = [] };
+        _userService.GetUsersByPageAsync(request, Arg.Any<CancellationToken>()).Returns(expected);
+
+        // Act
+        var result = await UserEndpoints.GetUsersAsync(request, _userService);
+
+        // Assert
+        var ok = Assert.IsType<Ok<PaginatedModel<UserDto>>>(result.Result);
+        Assert.Same(expected, ok.Value);
+    }
+
+    [Fact]
+    public void GivenHttpContext_WhenCurrentUserFeaturePresent_ThenReturnsThatUser()
+    {
+        // Arrange
+        var user = UserDtoBuilder.Valid().WithId(5).Build();
+        var httpContext = new DefaultHttpContext();
+        httpContext.Features.Set<ICurrentUserFeature>(new CurrentUserFeature { User = user });
+
+        // Act
+        var result = UserEndpoints.GetExecutingUser(httpContext);
+
+        // Assert
+        Assert.Same(user, result.Value);
+    }
+
+    [Fact]
+    public void GivenHttpContext_WhenCurrentUserFeatureMissing_ThenThrowsArgumentNull()
+    {
+        // Arrange
+        var httpContext = new DefaultHttpContext();
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => UserEndpoints.GetExecutingUser(httpContext));
+    }
+}
+```
+
+- [ ] **Step 3: Run the tests**
+
+```bash
+dotnet test test/UnitTests/MoneyGroup.UnitTests.csproj
+```
+
+Expected: PASS, `total: 79`.
+
+- [ ] **Step 4: Final full-suite verification — Phase 3 gate**
+
+```bash
+docker exec -w /mssql-server-setup-scripts.d moneygroup-mssql-1 bash ./reset.sh
+dotnet test --solution MoneyGroup.slnx
+```
+
+Expected: `total: 106` (79 unit + 6 integration + 20 functional + 1 smoke), `failed: 0`, `skipped: 2`.
+
+- [ ] **Step 5: Verify formatting and coverage**
+
+```bash
+dotnet format MoneyGroup.slnx --verify-no-changes -v diag --severity info
+```
+
+Expected: no changes required.
+
+```bash
+dotnet test --solution MoneyGroup.slnx --coverage --config-file $PWD/testconfig.json
+dotnet coverage merge ./test/*/bin/Debug/net10.0/TestResults/*.xml --output coverage.xml --output-format xml
+```
+
+Expected: roughly 68.4% overall. **This looks low because the denominator still counts generated code — that is expected and correct. Do not modify `testconfig.json`.**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add test/UnitTests/WebApi/Endpoints
+git commit -m "test: add endpoint handler unit tests
+
+Handlers return typed Results<,>, so Ok/NotFound branches assert
+directly with no host and no database. Covers GetExecutingUser, whose
+CurrentUserFeature path had no test because the functional suite's two
+/my tests are skipped."
+```
+
+- [ ] **Step 7: Clean up the coverage artifact**
+
+```bash
+git status --short
+```
+
+If `coverage.xml` is untracked, delete it — it is a build artifact:
+
+```bash
+rm -f coverage.xml
+```
+
+Confirm the tree is clean before finishing.
+
+---
+
+## Completion criteria
+
+- [ ] `dotnet test --solution MoneyGroup.slnx` reports **106 total, 0 failed, 2 skipped** (after a seed reset)
+- [ ] `dotnet format MoneyGroup.slnx --verify-no-changes` passes
+- [ ] `grep -rn "Moq" test --include=*.cs --include=*.csproj` returns nothing
+- [ ] Every test method in `test/UnitTests` is named `Given…_When…_Then…`
+- [ ] `testconfig.json` is unmodified
+- [ ] No `#pragma warning disable` was added
+- [ ] Working tree is clean; `src/WebApi/MoneyGroup.WebApi.json` is unmodified
+
+## Known-open on completion
+
+The functional suite still corrupts its own seed data — `DeleteOrder_ValidId_ReturnsNoContent` deletes Order 3 and `CreateOrder_ValidDto_ReturnsCreatedOrder` leaks rows, so a second consecutive local run fails. This is deliberate: Slice 2 (Testcontainers + Respawn) fixes the root cause. Run the seed reset before any full-suite run.

--- a/docs/superpowers/specs/2026-08-15-unit-test-foundation-design.md
+++ b/docs/superpowers/specs/2026-08-15-unit-test-foundation-design.md
@@ -122,7 +122,7 @@ design complaint, but it is not a coverage hole. The audit's claim that closing 
 
 ```
 test/
-  UnitTests/          pure, in-memory, no host, no DB.        36 → ~76 tests
+  UnitTests/          pure, in-memory, no host, no DB.          8 → 79 tests
     Builders/         hand-written test-data builders
     Core/             services, specifications
     Infrastructure/   Mapperly mapper
@@ -246,8 +246,9 @@ Phase-specific gates:
 
 - **Phase 1** — test count is exactly 63 before and after; `FunctionalTests` reports 20.
 - **Phase 2** — count stays 63; no `Moq` reference remains in any test project.
-- **Phase 3** — count reaches ~103; coverage ~68.4% under the unchanged `testconfig.json`
-  (2526+15 covered of 3716); `dotnet format` clean.
+- **Phase 3** — count reaches 106 (79 unit + 6 integration + 20 functional + 1 smoke);
+  coverage ~68.4% under the unchanged `testconfig.json` (2526+15 covered of 3716);
+  `dotnet format` clean.
 
 The Phase 3 coverage gate looks unimpressive because the denominator still includes
 generated code. Against hand-written code only it is ~91%. Do not "fix" this by editing

--- a/docs/superpowers/specs/2026-08-15-unit-test-foundation-design.md
+++ b/docs/superpowers/specs/2026-08-15-unit-test-foundation-design.md
@@ -1,0 +1,303 @@
+# Unit-Test Foundation — Design
+
+**Date:** 2026-08-15
+**Status:** Approved
+**Slice:** 1 of 4 (see *Deferred work* for the remainder)
+**Baseline:** `main` @ `fc33b0a` — 63 tests, 0 failures, 2 skipped
+
+---
+
+## Problem
+
+The test suite's shape does not match what it tests.
+
+Of 48 tests in `MoneyGroup.FunctionalTests`, **28 never start a host, never issue an
+HTTP request and never touch a database.** They construct a plain object and call a
+method — they are unit tests living in the functional project. The consequence is not
+per-test runtime; it is that the project references `Microsoft.AspNetCore.Mvc.Testing`
+and all of `WebApi`, so there is no way to run "just the fast tests", and a reader
+cannot tell which level of the pyramid a file belongs to.
+
+Separately, the reported coverage figure is misleading. 82% of the lines counted are
+generated code — OpenAPI XML-comment transformers, the JSON source-generator context,
+the minimal-API route builder, Mapperly. Hand-written code is already ~89% covered, but
+the number reported to Codecov and SonarCloud is 68%.
+
+Full findings and evidence: see the test-suite audit
+(`https://claude.ai/code/artifact/50a27bf9-5108-44e3-abfa-628327d805e1`).
+
+## Goals
+
+1. Report a coverage number that reflects code humans wrote.
+2. Put every test in a project whose name describes what it actually does.
+3. Establish one idiom — mocking library, naming convention, data construction — before
+   the bulk of the suite gets written.
+4. Close the gaps that are unit-testable.
+
+## Non-goals
+
+- **Moving the coverage number materially.** It moves 68% → 89% from configuration in
+  Phase 0, then only ~+1.5% from Phase 3. This is expected. The remaining genuinely
+  uncovered lines live in deferred slices (see *Coverage reality* below).
+- Database isolation, authorization testing, CI restructuring, Postgres support. All
+  deferred — see *Deferred work*.
+- Fixing the functional suite's seed-data corruption. Deferred to Slice 2, whose
+  Testcontainers + Respawn work fixes the root cause; a stopgap here would be throwaway.
+
+## Constraints
+
+- **.NET 10** (`global.json` pins SDK `10.0.302`, `rollForward: latestMinor`).
+- **xUnit v3** via `xunit.v3.mtp-v2` 3.2.2 on Microsoft.Testing.Platform. Not changing.
+- **Central package management** — all versions go in `Directory.Packages.props`.
+- **`TreatWarningsAsErrors=true`** (`Directory.Build.props`). New code must be
+  warning-clean; do not add `#pragma warning disable`.
+- **Lock files** — `RestorePackagesWithLockFile=true`. Any new package requires the
+  affected `packages.lock.json` to be regenerated and committed, or CI fails under
+  `RestoreLockedMode`.
+- The functional suite requires a seeded SQL Server and remains locally fragile for the
+  whole of this slice. `src/Infrastructure.SqlServer/Docker/scripts/reset.sh` (run inside
+  the container) restores the seed.
+
+---
+
+## Coverage reality
+
+Measured on `main` @ `fc33b0a`, full suite, after a seed reset.
+
+| Configuration | Coverage | Denominator |
+|---|---:|---:|
+| Current `testconfig.json` | 68.0% | 3716 lines |
+| Excluding `[GeneratedCode]` + `[ExcludeFromCodeCoverage]` | **89.0%** | 662 lines |
+| Also excluding `[CompilerGenerated]` | 93.7% | 333 lines |
+
+The third row is **rejected**: `CompilerGeneratedAttribute` covers async state machines,
+and every service and handler method in this codebase is async. Excluding it produces a
+flattering number by hiding real logic. Verified — under that config `Core` drops from
+128 tracked lines to 94, losing the `OrderService` async bodies.
+
+Where the 73 genuinely-uncovered lines live under the accepted configuration:
+
+| Lines | Location | Slice |
+|---:|---|---|
+| 18 | `DenyUnauthorizedUserHandler.HandleRequirementAsync` — `CurrentUserFeature` branch | 3 (auth) |
+| ~24 | `EfRepository` `AddAsync` / `UpdateAsync` / `FirstOrDefaultAsync` / `AnyAsync` | 2 (repo integration) |
+| 5 | `UserEndpoints` `/my` | 3 (auth) |
+| ~10 | `UserByEmailSpec`, `UserPaginatedSpec`, `UserService.GetUserByEmailAsync` | **1 (this slice)** |
+| ~16 | `Program` else-branch, `ApplicationDbContext`, framework metadata | not worth chasing |
+
+**Correction to the original audit:** `UserService` is *not* uncovered — the functional
+tests exercise it indirectly. Only `GetUserByEmailAsync` (3 lines) is uncovered, and only
+because authorization is bypassed. It has no *direct unit test*, which remains a valid
+design complaint, but it is not a coverage hole. The audit's claim that closing these gaps
+"is where coverage actually moves" was wrong.
+
+---
+
+## Decisions
+
+| # | Decision | Outcome | Rationale |
+|---|---|---|---|
+| D1 | Unit-test topology | One `test/UnitTests` project referencing `WebApi` | `WebApi` transitively covers `Core` and `Infrastructure`. Three layer-split projects is over-structure for ~1400 lines of source. |
+| D2 | How the 28 tests move | Move as-is in Phase 1; rename in Phase 2 | Keeps the "moved" diff separate from the "changed" diff. Test count parity is the check. |
+| D5 | Mocking library | NSubstitute | No `Setup`/`.Object` ceremony; readability is the stated goal. Also lets `Mock<ClaimsPrincipal>` be replaced by a real principal. |
+| D6 | Assertion library | **Deferred** — stay on xUnit `Assert` | The `ShouldBe` argument order reverses relative to `Assert.Equal`, making silent wrong-direction assertions the main hazard in this slice. Revisit as its own cycle. |
+| D7 | Test framework | xUnit v3, unchanged | Already current. Not the problem. |
+| D8 | Test data | Hand-written builders | Explicit and reproducible; AutoFixture's randomness complicates failure reproduction for four DTOs. |
+| D10 | Endpoint handlers | `internal` + `InternalsVisibleTo` | Handlers return typed `Results<,>`, directly assertable. Extends a pattern already present twice in the repo. |
+| — | Naming convention | `Given_When_Then` | Chosen for readability on the validator-heavy tests Phase 3 adds. Costs ~36 renames in this slice. |
+| — | Coverage config | `[GeneratedCode]` exclusion only | See *Coverage reality*. |
+| — | Sonar coverage path | **Not touched** | `sonar.cs.vscoveragexml.reportsPaths` is absent from `dotnet.yml`, but SonarCloud is reported as configured correctly. Revisit only if Sonar shows a problem. |
+
+---
+
+## Architecture
+
+### Target project shape
+
+```
+test/
+  UnitTests/          pure, in-memory, no host, no DB.        36 → ~76 tests
+    Builders/         hand-written test-data builders
+    Core/             services, specifications
+    Infrastructure/   Mapperly mapper
+    WebApi/           validators, authorization, endpoints, middleware
+  IntegrationTests/   real EF Core + SQL Server.                       6 tests
+  FunctionalTests/    HTTP through WebApplicationFactory.      48 → 20 tests
+  AppHost.Tests/      Aspire smoke.                                    1 test
+```
+
+Folders inside `UnitTests` mirror `src/` so the test for a type is findable from its
+path. `UnitTests` gains one project reference:
+
+```xml
+<ProjectReference Include="..\..\src\WebApi\MoneyGroup.WebApi.csproj" />
+```
+
+`FunctionalTests` loses its `Moq` package reference (nothing there mocks after the move).
+
+**Accepted trade-off:** nothing structurally prevents a host-based test being added to
+`UnitTests` once it references `WebApi`. Mitigated by folder convention and review, not
+by the build. The alternative — three layer-split test projects — was rejected as
+over-structure at this codebase size.
+
+### Phase 0 — coverage configuration
+
+`testconfig.json`, one file, no test changes:
+
+```json
+{
+    "codeCoverage": {
+        "Configuration": {
+            "Format": "xml",
+            "CodeCoverage": {
+                "Attributes": {
+                    "Exclude": [
+                        "^System\\.CodeDom\\.Compiler\\.GeneratedCodeAttribute$",
+                        "^System\\.Diagnostics\\.CodeAnalysis\\.ExcludeFromCodeCoverageAttribute$"
+                    ]
+                },
+                "Sources": {
+                    "Exclude": [ ".*\\\\Migrations\\\\.*.cs" ]
+                }
+            }
+        }
+    }
+}
+```
+
+**CI propagation requires no workflow change.** `.github/workflows/dotnet.yml` already
+runs `dotnet test --coverage --config-file $pwd/testconfig.json`, so per-project reports
+are filtered at generation. `dotnet coverage merge` preserves that filtering, and
+`codecov-action` consumes the merged `coverage.xml`.
+
+Ships as its own commit. 68% → 89% is a *jump*, so it is safe against Codecov's default
+"must not decrease" project status, but it permanently rebases the history — the commit
+message must explain the discontinuity.
+
+### Phase 1 — relocation
+
+| From | To |
+|---|---|
+| `FunctionalTests/Validators/OrderDtoValidatorTest.cs` | `UnitTests/WebApi/Validators/OrderDtoValidatorTests.cs` |
+| `FunctionalTests/Validators/OrderPaginatedRequestValidatorTests.cs` | `UnitTests/WebApi/Validators/OrderPaginatedRequestValidatorTests.cs` |
+| `FunctionalTests/Validators/ParticipantDtoValidatorTest.cs` | `UnitTests/WebApi/Validators/ParticipantDtoValidatorTests.cs` |
+| `FunctionalTests/Authorizations/DenyUnauthorizedUserHandlerTest.cs` | `UnitTests/WebApi/Authorizations/DenyUnauthorizedUserHandlerTests.cs` |
+| `UnitTests/Services/OrderServiceTest.cs` | `UnitTests/Core/Services/OrderServiceTests.cs` |
+
+Namespaces follow the folders. Class-name suffix standardizes on `Tests`.
+`[Trait("Category", "Unit")]` is added at class level — the project split is the real
+fast-run mechanism, but traits give Slice 4's CI filtering something to select on.
+
+Two fixture cleanups land here because they are part of moving the files, not separate
+behaviour changes:
+
+- `OrderDtoValidatorTestFixture` (an `IClassFixture` wrapping a stateless validator) is
+  deleted; the validator becomes a plain field.
+- `ParticipantDtoValidatorTest : IClassFixture<ParticipantDtoValidator>` — which uses a
+  **production type** as an xUnit fixture — becomes a plain field.
+
+**Invariant: total test count must be 63 before and after.** No assertion or logic edits.
+
+### Phase 2 — lock the idiom
+
+Three mechanical passes, each its own commit, each ending green.
+
+1. **Moq → NSubstitute** across the ~36 unit tests. `Mock<ClaimsPrincipal>` is replaced
+   by a real `ClaimsPrincipal` built from `ClaimsPrincipalBuilder`, removing the current
+   coupling to `FindFirstValue`'s internal call to `FindFirst`.
+2. **`Given_When_Then` renames** across the same tests.
+3. **Builders** introduced under `UnitTests/Builders/`, and the duplicated inline literals
+   collapsed onto them.
+
+Also retires `#pragma warning disable CA1859` in `OrderServiceTests` by typing the field
+as `OrderService` rather than `IOrderService`.
+
+Builder shape — fluent, immutable-in, explicit defaults, no randomness:
+
+```csharp
+var dto = OrderDtoBuilder.Valid()
+    .WithBuyer(1)
+    .WithParticipants(1, 2)
+    .Build();
+```
+
+Builders live in `UnitTests` only for this slice. If Slice 2 needs them for integration
+tests, promoting them to a shared project is that slice's decision.
+
+### Phase 3 — close the unit-testable gaps
+
+| Target | New tests | Coverage effect |
+|---|---:|---|
+| `UserService` — 3 methods | ~6 | +3 lines |
+| 6 specifications | ~12 | +7 lines |
+| Mapperly `Mapper` | ~6 | 0 — generated, now excluded |
+| `BusinessValidationExceptionHandler` | ~4 | 0 — already covered |
+| `OrderService.GetOrdersByPageAsync` | ~2 | 0 |
+| 7 endpoint handlers | ~10 | +5 lines |
+
+The Mapperly and exception-handler tests contribute no coverage but are the highest-value
+tests in the phase: a source-generated mapper silently dropping a property is exactly the
+failure that `Assert.NotNull` in a functional test cannot catch.
+
+**Production change — the only one in this slice.** All 7 minimal-API handlers in
+`OrderEndpoints` and `UserEndpoints` normalize to `internal static`, resolving an existing
+inconsistency (`GetOrderByIdAsync` and `GetUserByIdAsync` are already `public static`
+while their siblings are `private static`). Plus one line in `MoneyGroup.WebApi.csproj`:
+
+```xml
+<InternalsVisibleTo Include="MoneyGroup.UnitTests" />
+```
+
+This extends a pattern already used twice — `WebApi → FunctionalTests` and
+`Infrastructure → IntegrationTests`.
+
+---
+
+## Verification
+
+Every phase ends with a green run; no phase is complete on a red suite.
+
+| Check | Command |
+|---|---|
+| Fast loop | `dotnet test test/UnitTests/MoneyGroup.UnitTests.csproj` |
+| Full suite | seed reset, then `dotnet test --solution MoneyGroup.slnx` |
+| Coverage delta | `dotnet test --solution MoneyGroup.slnx --coverage --config-file $PWD/testconfig.json` then `dotnet coverage merge` |
+| Format gate | `dotnet format MoneyGroup.slnx --verify-no-changes -v diag --severity info` |
+
+Seed reset, required before any full-suite run until Slice 2:
+
+```bash
+docker exec -w /mssql-server-setup-scripts.d moneygroup-mssql-1 bash ./reset.sh
+```
+
+Phase-specific gates:
+
+- **Phase 0** — coverage rises to ~89% with no change in test count or results.
+- **Phase 1** — test count is exactly 63 before and after; `FunctionalTests` reports 20.
+- **Phase 2** — count stays 63; no `Moq` reference remains in any test project.
+- **Phase 3** — count reaches ~103; coverage ~91% (589+15 covered of 662); `dotnet format` clean.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| A moved test silently disappears (namespace or file collision) | Assert exact test-count parity at Phase 1; 63 before, 63 after |
+| NSubstitute rewrite changes assertion semantics — `Received()` is not `Verify()` and a missing `Received` assertion passes silently | Convert one file per commit with a green run between; every converted `Verify` must become an explicit `Received` |
+| `UnitTests` referencing `WebApi` invites host-based tests | Folder convention + review. Accepted trade-off of the one-project decision |
+| Given_When_Then churn produces a large, noisy diff | Renames are their own commit, separate from behaviour changes |
+| New package versions break the CI lock-file gate | Regenerate and commit `packages.lock.json` in the same commit that adds NSubstitute |
+| Coverage baseline discontinuity confuses later comparison | Phase 0 ships alone with an explanatory commit message |
+
+## Deferred work
+
+| Slice | Content | Why deferred |
+|---|---|---|
+| 2 | Testcontainers.MsSql + Respawn; provider-parameterised DbContext factory; `EfRepository` integration tests (~24 uncovered lines) | Needs its own design; fixes the seed corruption at the root |
+| 3 | `TestAuthHandler`; un-skip the two `/my` tests; `CurrentUserFeature` (~23 uncovered lines) | Largest single coverage block, but needs Slice 2's fixtures |
+| 4 | CI fast/slow job split; Aspire nightly; `src/AppHost` coverage exclusion shipped in the same commit | Depends on Phase 1's traits |
+| later | Postgres as a second provider | Wanted, explicitly not now. Slice 2 builds the seam so this is additive |
+| later | Shouldly adoption | D6 deferred; converts ~76 tests if taken up after this slice |
+
+**Known-open while this slice runs:** the functional suite corrupts its own seed data
+(deletes Order 3, leaks `New order` rows) and fails on a second consecutive local run.
+CI is unaffected — its container is recreated per run and self-seeds. Slice 2 fixes it.

--- a/docs/superpowers/specs/2026-08-15-unit-test-foundation-design.md
+++ b/docs/superpowers/specs/2026-08-15-unit-test-foundation-design.md
@@ -28,17 +28,18 @@ Full findings and evidence: see the test-suite audit
 
 ## Goals
 
-1. Report a coverage number that reflects code humans wrote.
-2. Put every test in a project whose name describes what it actually does.
-3. Establish one idiom — mocking library, naming convention, data construction — before
+1. Put every test in a project whose name describes what it actually does.
+2. Establish one idiom — mocking library, naming convention, data construction — before
    the bulk of the suite gets written.
-4. Close the gaps that are unit-testable.
+3. Close the gaps that are unit-testable.
 
 ## Non-goals
 
-- **Moving the coverage number materially.** It moves 68% → 89% from configuration in
-  Phase 0, then only ~+1.5% from Phase 3. This is expected. The remaining genuinely
-  uncovered lines live in deferred slices (see *Coverage reality* below).
+- **Moving the coverage number materially.** Phase 3 adds ~15 covered lines, which against
+  the current denominator is 68.0% → ~68.4%. This is expected, not a shortfall. The
+  *reported* figure is distorted by generated code, but correcting that is deferred — see
+  *Coverage reality* below.
+- **Changing coverage configuration.** `testconfig.json` is not touched in this slice.
 - Database isolation, authorization testing, CI restructuring, Postgres support. All
   deferred — see *Deferred work*.
 - Fixing the functional suite's seed-data corruption. Deferred to Slice 2, whose
@@ -61,6 +62,11 @@ Full findings and evidence: see the test-suite audit
 ---
 
 ## Coverage reality
+
+> **Analysis only — no configuration change ships in this slice.** The exclusion described
+> here is deferred: it rebases a metric the team is managed on, and should not land until
+> whoever owns that metric understands it. Recorded here so the analysis is not lost and
+> the change can be picked up deliberately later.
 
 Measured on `main` @ `fc33b0a`, full suite, after a seed reset.
 
@@ -105,7 +111,7 @@ design complaint, but it is not a coverage hole. The audit's claim that closing 
 | D8 | Test data | Hand-written builders | Explicit and reproducible; AutoFixture's randomness complicates failure reproduction for four DTOs. |
 | D10 | Endpoint handlers | `internal` + `InternalsVisibleTo` | Handlers return typed `Results<,>`, directly assertable. Extends a pattern already present twice in the repo. |
 | — | Naming convention | `Given_When_Then` | Chosen for readability on the validator-heavy tests Phase 3 adds. Costs ~36 renames in this slice. |
-| — | Coverage config | `[GeneratedCode]` exclusion only | See *Coverage reality*. |
+| — | Coverage config | **Deferred** — `testconfig.json` untouched | Rebases a managed metric; should not ship until its owner understands it. Analysis retained under *Coverage reality*. |
 | — | Sonar coverage path | **Not touched** | `sonar.cs.vscoveragexml.reportsPaths` is absent from `dotnet.yml`, but SonarCloud is reported as configured correctly. Revisit only if Sonar shows a problem. |
 
 ---
@@ -139,40 +145,6 @@ path. `UnitTests` gains one project reference:
 `UnitTests` once it references `WebApi`. Mitigated by folder convention and review, not
 by the build. The alternative — three layer-split test projects — was rejected as
 over-structure at this codebase size.
-
-### Phase 0 — coverage configuration
-
-`testconfig.json`, one file, no test changes:
-
-```json
-{
-    "codeCoverage": {
-        "Configuration": {
-            "Format": "xml",
-            "CodeCoverage": {
-                "Attributes": {
-                    "Exclude": [
-                        "^System\\.CodeDom\\.Compiler\\.GeneratedCodeAttribute$",
-                        "^System\\.Diagnostics\\.CodeAnalysis\\.ExcludeFromCodeCoverageAttribute$"
-                    ]
-                },
-                "Sources": {
-                    "Exclude": [ ".*\\\\Migrations\\\\.*.cs" ]
-                }
-            }
-        }
-    }
-}
-```
-
-**CI propagation requires no workflow change.** `.github/workflows/dotnet.yml` already
-runs `dotnet test --coverage --config-file $pwd/testconfig.json`, so per-project reports
-are filtered at generation. `dotnet coverage merge` preserves that filtering, and
-`codecov-action` consumes the merged `coverage.xml`.
-
-Ships as its own commit. 68% → 89% is a *jump*, so it is safe against Codecov's default
-"must not decrease" project status, but it permanently rebases the history — the commit
-message must explain the discontinuity.
 
 ### Phase 1 — relocation
 
@@ -272,10 +244,14 @@ docker exec -w /mssql-server-setup-scripts.d moneygroup-mssql-1 bash ./reset.sh
 
 Phase-specific gates:
 
-- **Phase 0** — coverage rises to ~89% with no change in test count or results.
 - **Phase 1** — test count is exactly 63 before and after; `FunctionalTests` reports 20.
 - **Phase 2** — count stays 63; no `Moq` reference remains in any test project.
-- **Phase 3** — count reaches ~103; coverage ~91% (589+15 covered of 662); `dotnet format` clean.
+- **Phase 3** — count reaches ~103; coverage ~68.4% under the unchanged `testconfig.json`
+  (2526+15 covered of 3716); `dotnet format` clean.
+
+The Phase 3 coverage gate looks unimpressive because the denominator still includes
+generated code. Against hand-written code only it is ~91%. Do not "fix" this by editing
+`testconfig.json` — that change is deliberately deferred.
 
 ## Risks
 
@@ -286,7 +262,7 @@ Phase-specific gates:
 | `UnitTests` referencing `WebApi` invites host-based tests | Folder convention + review. Accepted trade-off of the one-project decision |
 | Given_When_Then churn produces a large, noisy diff | Renames are their own commit, separate from behaviour changes |
 | New package versions break the CI lock-file gate | Regenerate and commit `packages.lock.json` in the same commit that adds NSubstitute |
-| Coverage baseline discontinuity confuses later comparison | Phase 0 ships alone with an explanatory commit message |
+| `src/WebApi/MoneyGroup.WebApi.json` (generated OpenAPI doc, `text: auto`) re-churns line endings on every Windows build and gets swept into a commit | Never `git add -A`; stage explicit paths. `git diff --numstat` on it is empty when the change is line-endings only |
 
 ## Deferred work
 
@@ -297,6 +273,40 @@ Phase-specific gates:
 | 4 | CI fast/slow job split; Aspire nightly; `src/AppHost` coverage exclusion shipped in the same commit | Depends on Phase 1's traits |
 | later | Postgres as a second provider | Wanted, explicitly not now. Slice 2 builds the seam so this is additive |
 | later | Shouldly adoption | D6 deferred; converts ~76 tests if taken up after this slice |
+| later | Coverage-config correction | Deferred pending owner understanding. Self-contained, ~15 min, no test changes — see below |
+
+### Deferred: coverage-config correction
+
+Recorded so it can be picked up deliberately. Adds two attribute exclusions to
+`testconfig.json`; takes the reported figure from 68.0% to 89.0% by removing generated
+code from the denominator.
+
+```json
+"CodeCoverage": {
+    "Attributes": {
+        "Exclude": [
+            "^System\\.CodeDom\\.Compiler\\.GeneratedCodeAttribute$",
+            "^System\\.Diagnostics\\.CodeAnalysis\\.ExcludeFromCodeCoverageAttribute$"
+        ]
+    },
+    "Sources": { "Exclude": [ ".*\\\\Migrations\\\\.*.cs" ] }
+}
+```
+
+Notes for whoever takes it:
+
+- **No workflow change needed.** `.github/workflows/dotnet.yml` already runs
+  `dotnet test --coverage --config-file $pwd/testconfig.json`, so reports are filtered at
+  generation; `dotnet coverage merge` preserves it and `codecov-action` consumes the
+  merged `coverage.xml`.
+- **Do not add `CompilerGeneratedAttribute`.** It yields a flattering 93.7% by excluding
+  async state machines — i.e. the body of every service and handler method here.
+- 68% → 89% is a *rise*, so it passes Codecov's default "must not decrease" status, but it
+  permanently rebases history. Ship alone, with a commit message explaining the
+  discontinuity.
+- Unrelated but adjacent: `dotnet.yml` passes no
+  `/d:sonar.cs.vscoveragexml.reportsPaths`. SonarCloud is reported as configured
+  correctly, so this is only worth revisiting if Sonar shows a coverage problem.
 
 **Known-open while this slice runs:** the functional suite corrupts its own seed data
 (deletes Order 3, leaks `New order` rows) and fails on a second consecutive local run.

--- a/src/WebApi/Endpoints/OrderEndpoints.cs
+++ b/src/WebApi/Endpoints/OrderEndpoints.cs
@@ -31,19 +31,19 @@ public static class OrderEndpoints
         .WithName("DeleteOrder");
     }
 
-    private static async Task<Results<Ok<PaginatedModel<OrderDetailedDto>>, ValidationProblem>> GetOrdersAsync([AsParameters] OrderPaginatedRequest request, [FromServices] IOrderService orderService)
+    internal static async Task<Results<Ok<PaginatedModel<OrderDetailedDto>>, ValidationProblem>> GetOrdersAsync([AsParameters] OrderPaginatedRequest request, [FromServices] IOrderService orderService)
     {
         var orders = await orderService.GetOrdersByPageAsync(request);
         return TypedResults.Ok(orders);
     }
 
-    private static async Task<Results<CreatedAtRoute<OrderDto>, ValidationProblem>> CreateOrderAsync(OrderDto input, IOrderService orderService)
+    internal static async Task<Results<CreatedAtRoute<OrderDto>, ValidationProblem>> CreateOrderAsync(OrderDto input, IOrderService orderService)
     {
         await orderService.CreateOrderAsync(input);
         return TypedResults.CreatedAtRoute(input, "GetOrderById", new { id = input.Id });
     }
 
-    private static async Task<Results<NoContent, NotFound>> DeleteOrderAsync(int id, IOrderService orderService, CancellationToken cancellationToken)
+    internal static async Task<Results<NoContent, NotFound>> DeleteOrderAsync(int id, IOrderService orderService, CancellationToken cancellationToken)
     {
         var result = await orderService.RemoveOrderAsync(id, cancellationToken);
         return !result
@@ -51,7 +51,7 @@ public static class OrderEndpoints
             : TypedResults.NoContent();
     }
 
-    public static async Task<Results<Ok<OrderDetailedDto>, NotFound>> GetOrderByIdAsync(int id, IOrderService orderService)
+    internal static async Task<Results<Ok<OrderDetailedDto>, NotFound>> GetOrderByIdAsync(int id, IOrderService orderService)
     {
         var order = await orderService.GetOrderByIdAsync(id);
         return order == null

--- a/src/WebApi/Endpoints/UserEndpoints.cs
+++ b/src/WebApi/Endpoints/UserEndpoints.cs
@@ -29,13 +29,13 @@ public static class UserEndpoints
         .WithName("GetExecutingUser");
     }
 
-    private static async Task<Results<Ok<PaginatedModel<UserDto>>, ValidationProblem>> GetUsersAsync([AsParameters] UserPaginatedRequest request, [FromServices] IUserService userService)
+    internal static async Task<Results<Ok<PaginatedModel<UserDto>>, ValidationProblem>> GetUsersAsync([AsParameters] UserPaginatedRequest request, [FromServices] IUserService userService)
     {
         var users = await userService.GetUsersByPageAsync(request);
         return TypedResults.Ok(users);
     }
 
-    public static async Task<Results<Ok<UserDto>, NotFound>> GetUserByIdAsync(int id, [FromServices] IUserService userService, CancellationToken cancellationToken)
+    internal static async Task<Results<Ok<UserDto>, NotFound>> GetUserByIdAsync(int id, [FromServices] IUserService userService, CancellationToken cancellationToken)
     {
         var user = await userService.GetUserByIdAsync(id, cancellationToken);
         return user == null
@@ -43,7 +43,7 @@ public static class UserEndpoints
             : TypedResults.Ok(user);
     }
 
-    public static Ok<UserDto> GetExecutingUser(HttpContext httpContext)
+    internal static Ok<UserDto> GetExecutingUser(HttpContext httpContext)
     {
         var feature = httpContext.Features.Get<ICurrentUserFeature>();
         ArgumentNullException.ThrowIfNull(feature?.User);

--- a/src/WebApi/MoneyGroup.WebApi.csproj
+++ b/src/WebApi/MoneyGroup.WebApi.csproj
@@ -41,6 +41,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="MoneyGroup.FunctionalTests" />
+    <InternalsVisibleTo Include="MoneyGroup.UnitTests" />
   </ItemGroup>
 
 </Project>

--- a/test/FunctionalTests/MoneyGroup.FunctionalTests.csproj
+++ b/test/FunctionalTests/MoneyGroup.FunctionalTests.csproj
@@ -16,7 +16,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
-    <PackageReference Include="Moq" />
     <PackageReference Include="xunit.v3.mtp-v2" />
   </ItemGroup>
 

--- a/test/FunctionalTests/packages.lock.json
+++ b/test/FunctionalTests/packages.lock.json
@@ -24,15 +24,6 @@
           "Microsoft.Testing.Platform": "2.2.3"
         }
       },
-      "Moq": {
-        "type": "Direct",
-        "requested": "[4.20.72, )",
-        "resolved": "4.20.72",
-        "contentHash": "EA55cjyNn8eTNWrgrdZJH5QLFp2L43oxl1tlkoYUKIE9pRwL784OWiTXeCV5ApS+AMYEAlt7Fo03A2XfouvHmQ==",
-        "dependencies": {
-          "Castle.Core": "5.1.1"
-        }
-      },
       "xunit.v3.mtp-v2": {
         "type": "Direct",
         "requested": "[3.2.2, )",
@@ -42,14 +33,6 @@
           "xunit.analyzers": "1.27.0",
           "xunit.v3.assert": "[3.2.2]",
           "xunit.v3.core.mtp-v2": "[3.2.2]"
-        }
-      },
-      "Castle.Core": {
-        "type": "Transitive",
-        "resolved": "5.1.1",
-        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
-        "dependencies": {
-          "System.Diagnostics.EventLog": "6.0.0"
         }
       },
       "Microsoft.ApplicationInsights": {

--- a/test/UnitTests/Builders/OrderDtoBuilder.cs
+++ b/test/UnitTests/Builders/OrderDtoBuilder.cs
@@ -50,7 +50,7 @@ public sealed class OrderDtoBuilder
 
     public OrderDtoBuilder WithParticipants(params int[] participantIds)
     {
-        _participants = participantIds.Select(id => new ParticipantDto { ParticipantId = id }).ToList();
+        _participants = [.. participantIds.Select(id => new ParticipantDto { ParticipantId = id })];
         return this;
     }
 

--- a/test/UnitTests/Builders/OrderDtoBuilder.cs
+++ b/test/UnitTests/Builders/OrderDtoBuilder.cs
@@ -1,0 +1,84 @@
+using MoneyGroup.Core.Models.Orders;
+
+namespace MoneyGroup.UnitTests.Builders;
+
+/// <summary>
+/// Builds <see cref="OrderDto"/> instances for tests. <see cref="Valid"/> returns a
+/// dto that passes every OrderDtoValidator rule, so each test only states the one
+/// field it cares about.
+/// </summary>
+public sealed class OrderDtoBuilder
+{
+    private int _id;
+    private string _title = "Title";
+    private string? _description = "Description";
+    private decimal _total;
+    private int _buyerId = 1;
+    private IEnumerable<ParticipantDto> _participants = [new ParticipantDto { ParticipantId = 1 }];
+
+    public static OrderDtoBuilder Valid() => new();
+
+    public OrderDtoBuilder WithId(int id)
+    {
+        _id = id;
+        return this;
+    }
+
+    public OrderDtoBuilder WithTitle(string? title)
+    {
+        _title = title!;
+        return this;
+    }
+
+    public OrderDtoBuilder WithDescription(string? description)
+    {
+        _description = description;
+        return this;
+    }
+
+    public OrderDtoBuilder WithTotal(decimal total)
+    {
+        _total = total;
+        return this;
+    }
+
+    public OrderDtoBuilder WithBuyer(int buyerId)
+    {
+        _buyerId = buyerId;
+        return this;
+    }
+
+    public OrderDtoBuilder WithParticipants(params int[] participantIds)
+    {
+        _participants = participantIds.Select(id => new ParticipantDto { ParticipantId = id }).ToList();
+        return this;
+    }
+
+    public OrderDtoBuilder WithParticipants(IEnumerable<ParticipantDto> participants)
+    {
+        _participants = participants;
+        return this;
+    }
+
+    public OrderDtoBuilder WithNoParticipants()
+    {
+        _participants = [];
+        return this;
+    }
+
+    public OrderDtoBuilder WithNullParticipants()
+    {
+        _participants = null!;
+        return this;
+    }
+
+    public OrderDto Build() => new()
+    {
+        Id = _id,
+        Title = _title,
+        Description = _description,
+        Total = _total,
+        BuyerId = _buyerId,
+        Participants = _participants,
+    };
+}

--- a/test/UnitTests/Builders/UserDtoBuilder.cs
+++ b/test/UnitTests/Builders/UserDtoBuilder.cs
@@ -1,0 +1,40 @@
+using MoneyGroup.Core.Models.Users;
+
+namespace MoneyGroup.UnitTests.Builders;
+
+/// <summary>
+/// Builds <see cref="UserDto"/> instances for tests.
+/// </summary>
+public sealed class UserDtoBuilder
+{
+    private int _id = 1;
+    private string _name = "User";
+    private string? _email = "user@domain.com";
+
+    public static UserDtoBuilder Valid() => new();
+
+    public UserDtoBuilder WithId(int id)
+    {
+        _id = id;
+        return this;
+    }
+
+    public UserDtoBuilder WithName(string name)
+    {
+        _name = name;
+        return this;
+    }
+
+    public UserDtoBuilder WithEmail(string? email)
+    {
+        _email = email;
+        return this;
+    }
+
+    public UserDto Build() => new()
+    {
+        Id = _id,
+        Name = _name,
+        Email = _email,
+    };
+}

--- a/test/UnitTests/Core/Services/OrderServiceTests.cs
+++ b/test/UnitTests/Core/Services/OrderServiceTests.cs
@@ -1,5 +1,3 @@
-﻿using System.Linq.Expressions;
-
 using MoneyGroup.Core.Abstractions;
 using MoneyGroup.Core.Entities;
 using MoneyGroup.Core.Exceptions;
@@ -7,43 +5,40 @@ using MoneyGroup.Core.Models.Orders;
 using MoneyGroup.Core.Services;
 using MoneyGroup.Core.Specifications;
 
-using Moq;
+using NSubstitute;
 
 namespace MoneyGroup.UnitTests.Core.Services;
 
 [Trait("Category", "Unit")]
 public class OrderServiceTests
 {
-    private readonly Mock<IUserRepository> _userRepositoryMock;
-    private readonly Mock<IOrderRepository> _orderRepositoryMock;
+    private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
+    private readonly IOrderRepository _orderRepository = Substitute.For<IOrderRepository>();
     private readonly OrderService _orderService;
 
     public OrderServiceTests()
     {
-        _userRepositoryMock = new Mock<IUserRepository>();
-        _orderRepositoryMock = new Mock<IOrderRepository>();
-        _orderService = new OrderService(_orderRepositoryMock.Object, _userRepositoryMock.Object);
+        _orderService = new OrderService(_orderRepository, _userRepository);
     }
 
     [Fact]
     public async Task GetOrderByIdAsync_ValidId_ShouldReturnOrder()
     {
         // Arrange
-        int id = 1;
-        var orderDto = new OrderDetailedDto
-        {
-            Id = id,
-        };
-        CancellationToken cancellationToken = default;
+        var id = 1;
+        var orderDto = new OrderDetailedDto { Id = id };
+        var cancellationToken = TestContext.Current.CancellationToken;
 
-        _orderRepositoryMock.Setup(o => o.FirstOrDefaultAsync<OrderDetailedDto>(It.IsAny<EntityByIdSpec<Order>>(), cancellationToken))
-            .ReturnsAsync(orderDto);
+        _orderRepository
+            .FirstOrDefaultAsync<OrderDetailedDto>(Arg.Any<EntityByIdSpec<Order>>(), cancellationToken)
+            .Returns(orderDto);
 
         // Act
         var result = await _orderService.GetOrderByIdAsync(id, cancellationToken);
 
         // Assert
-        _orderRepositoryMock.Verify(o => o.FirstOrDefaultAsync<OrderDetailedDto>(It.IsAny<EntityByIdSpec<Order>>(), cancellationToken));
+        await _orderRepository.Received(1)
+            .FirstOrDefaultAsync<OrderDetailedDto>(Arg.Any<EntityByIdSpec<Order>>(), cancellationToken);
         Assert.NotNull(result);
         Assert.Equal(id, result.Id);
     }
@@ -52,17 +47,19 @@ public class OrderServiceTests
     public async Task GetOrderByIdAsync_InvalidId_ShouldReturnNull()
     {
         // Arrange
-        int invalidId = -1;
-        CancellationToken cancellationToken = default;
+        var invalidId = -1;
+        var cancellationToken = TestContext.Current.CancellationToken;
 
-        _orderRepositoryMock.Setup(o => o.FirstOrDefaultAsync<OrderDetailedDto>(It.IsAny<Expression<Func<Order, bool>>>(), cancellationToken))
-            .ReturnsAsync((OrderDetailedDto?)null);
+        _orderRepository
+            .FirstOrDefaultAsync<OrderDetailedDto>(Arg.Any<EntityByIdSpec<Order>>(), cancellationToken)
+            .Returns((OrderDetailedDto?)null);
 
         // Act
         var result = await _orderService.GetOrderByIdAsync(invalidId, cancellationToken);
 
         // Assert
-        _orderRepositoryMock.Verify(o => o.FirstOrDefaultAsync<OrderDetailedDto>(It.IsAny<EntityByIdSpec<Order>>(), cancellationToken));
+        await _orderRepository.Received(1)
+            .FirstOrDefaultAsync<OrderDetailedDto>(Arg.Any<EntityByIdSpec<Order>>(), cancellationToken);
         Assert.Null(result);
     }
 
@@ -81,14 +78,12 @@ public class OrderServiceTests
             ],
         };
 
-        _userRepositoryMock.Setup(u => u.AnyAsync(It.IsAny<EntityByIdSpec<User>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true);
-
-        _userRepositoryMock.Setup(u => u.CountAsync(It.IsAny<EntityByIdsSpec<User>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(2);
-
-        _orderRepositoryMock.Setup(o => o.AddAsync(It.IsAny<OrderDto>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(() =>
+        _userRepository.AnyAsync(Arg.Any<EntityByIdSpec<User>>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+        _userRepository.CountAsync(Arg.Any<EntityByIdsSpec<User>>(), Arg.Any<CancellationToken>())
+            .Returns(2);
+        _orderRepository.AddAsync(Arg.Any<OrderDto>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
             {
                 model.Id = newOrderId;
                 return model;
@@ -98,9 +93,9 @@ public class OrderServiceTests
         await _orderService.CreateOrderAsync(model, TestContext.Current.CancellationToken);
 
         // Assert
-        _userRepositoryMock.Verify(u => u.AnyAsync(It.IsAny<EntityByIdSpec<User>>(), It.IsAny<CancellationToken>()), Times.Once);
-        _userRepositoryMock.Verify(u => u.CountAsync(It.IsAny<EntityByIdsSpec<User>>(), It.IsAny<CancellationToken>()), Times.Once);
-        _orderRepositoryMock.Verify(o => o.AddAsync(It.IsAny<OrderDto>(), It.IsAny<CancellationToken>()));
+        await _userRepository.Received(1).AnyAsync(Arg.Any<EntityByIdSpec<User>>(), Arg.Any<CancellationToken>());
+        await _userRepository.Received(1).CountAsync(Arg.Any<EntityByIdsSpec<User>>(), Arg.Any<CancellationToken>());
+        await _orderRepository.Received(1).AddAsync(Arg.Any<OrderDto>(), Arg.Any<CancellationToken>());
         Assert.Equal(newOrderId, model.Id);
     }
 
@@ -112,14 +107,13 @@ public class OrderServiceTests
         var model = new OrderDto
         {
             BuyerId = 1,
-            Participants = []
+            Participants = [],
         };
 
-        _userRepositoryMock.Setup(u => u.AnyAsync(It.IsAny<EntityByIdSpec<User>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true);
-
-        _orderRepositoryMock.Setup(o => o.AddAsync(It.IsAny<OrderDto>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(() =>
+        _userRepository.AnyAsync(Arg.Any<EntityByIdSpec<User>>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+        _orderRepository.AddAsync(Arg.Any<OrderDto>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
             {
                 model.Id = newOrderId;
                 return model;
@@ -129,9 +123,9 @@ public class OrderServiceTests
         await _orderService.CreateOrderAsync(model, TestContext.Current.CancellationToken);
 
         // Assert
-        _userRepositoryMock.Verify(u => u.AnyAsync(It.IsAny<EntityByIdSpec<User>>(), It.IsAny<CancellationToken>()), Times.Once);
-        _userRepositoryMock.Verify(u => u.CountAsync(It.IsAny<EntityByIdsSpec<User>>(), It.IsAny<CancellationToken>()), Times.Never);
-        _orderRepositoryMock.Verify(o => o.AddAsync(It.IsAny<OrderDto>(), It.IsAny<CancellationToken>()));
+        await _userRepository.Received(1).AnyAsync(Arg.Any<EntityByIdSpec<User>>(), Arg.Any<CancellationToken>());
+        await _userRepository.DidNotReceive().CountAsync(Arg.Any<EntityByIdsSpec<User>>(), Arg.Any<CancellationToken>());
+        await _orderRepository.Received(1).AddAsync(Arg.Any<OrderDto>(), Arg.Any<CancellationToken>());
         Assert.Equal(newOrderId, model.Id);
     }
 
@@ -146,18 +140,19 @@ public class OrderServiceTests
             [
                 new() { ParticipantId = 2 },
                 new() { ParticipantId = 3 },
-            ]
+            ],
         };
 
-        _userRepositoryMock.Setup(u => u.AnyAsync(It.IsAny<EntityByIdSpec<User>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(false);
+        _userRepository.AnyAsync(Arg.Any<EntityByIdSpec<User>>(), Arg.Any<CancellationToken>())
+            .Returns(false);
 
         // Act
-        var ex = await Assert.ThrowsAsync<BuyerNotFoundException>(() => _orderService.CreateOrderAsync(model, TestContext.Current.CancellationToken));
+        var ex = await Assert.ThrowsAsync<BuyerNotFoundException>(
+            () => _orderService.CreateOrderAsync(model, TestContext.Current.CancellationToken));
 
         // Assert
-        _userRepositoryMock.Verify(u => u.AnyAsync(It.IsAny<EntityByIdSpec<User>>(), It.IsAny<CancellationToken>()));
-        _orderRepositoryMock.Verify(o => o.AddAsync(It.IsAny<OrderDto>(), It.IsAny<CancellationToken>()), Times.Never);
+        await _userRepository.Received(1).AnyAsync(Arg.Any<EntityByIdSpec<User>>(), Arg.Any<CancellationToken>());
+        await _orderRepository.DidNotReceive().AddAsync(Arg.Any<OrderDto>(), Arg.Any<CancellationToken>());
         Assert.Equal("Buyer not found", ex.Message);
     }
 
@@ -172,22 +167,22 @@ public class OrderServiceTests
             [
                 new() { ParticipantId = 2 },
                 new() { ParticipantId = -1 },
-            ]
+            ],
         };
 
-        _userRepositoryMock.Setup(u => u.AnyAsync(It.IsAny<EntityByIdSpec<User>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(true);
-
-        _userRepositoryMock.Setup(u => u.CountAsync(It.IsAny<EntityByIdsSpec<User>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(1); // Only 1 participant exists, but 2 were requested
+        _userRepository.AnyAsync(Arg.Any<EntityByIdSpec<User>>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+        _userRepository.CountAsync(Arg.Any<EntityByIdsSpec<User>>(), Arg.Any<CancellationToken>())
+            .Returns(1); // only 1 of the 2 requested participants exists
 
         // Act
-        var ex = await Assert.ThrowsAsync<ParticipantNotFoundException>(() => _orderService.CreateOrderAsync(model, TestContext.Current.CancellationToken));
+        var ex = await Assert.ThrowsAsync<ParticipantNotFoundException>(
+            () => _orderService.CreateOrderAsync(model, TestContext.Current.CancellationToken));
 
         // Assert
-        _userRepositoryMock.Verify(u => u.AnyAsync(It.IsAny<EntityByIdSpec<User>>(), It.IsAny<CancellationToken>()), Times.Once);
-        _userRepositoryMock.Verify(u => u.CountAsync(It.IsAny<EntityByIdsSpec<User>>(), It.IsAny<CancellationToken>()), Times.Once);
-        _orderRepositoryMock.Verify(o => o.AddAsync(It.IsAny<OrderDto>(), It.IsAny<CancellationToken>()), Times.Never);
+        await _userRepository.Received(1).AnyAsync(Arg.Any<EntityByIdSpec<User>>(), Arg.Any<CancellationToken>());
+        await _userRepository.Received(1).CountAsync(Arg.Any<EntityByIdsSpec<User>>(), Arg.Any<CancellationToken>());
+        await _orderRepository.DidNotReceive().AddAsync(Arg.Any<OrderDto>(), Arg.Any<CancellationToken>());
         Assert.Equal("Participant not found", ex.Message);
     }
 
@@ -198,19 +193,16 @@ public class OrderServiceTests
         var orderId = 1;
         var order = new Order { Id = orderId };
 
-        _orderRepositoryMock.Setup(o => o.FirstOrDefaultAsync(It.IsAny<EntityByIdSpec<Order>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(order);
-
-        _orderRepositoryMock.Setup(o => o.RemoveAsync(It.IsAny<Order>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
+        _orderRepository.FirstOrDefaultAsync(Arg.Any<EntityByIdSpec<Order>>(), Arg.Any<CancellationToken>())
+            .Returns(order);
 
         // Act
         var result = await _orderService.RemoveOrderAsync(orderId, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result);
-        _orderRepositoryMock.Verify(o => o.FirstOrDefaultAsync(It.IsAny<EntityByIdSpec<Order>>(), It.IsAny<CancellationToken>()));
-        _orderRepositoryMock.Verify(o => o.RemoveAsync(It.IsAny<Order>(), It.IsAny<CancellationToken>()));
+        await _orderRepository.Received(1).FirstOrDefaultAsync(Arg.Any<EntityByIdSpec<Order>>(), Arg.Any<CancellationToken>());
+        await _orderRepository.Received(1).RemoveAsync(order, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -219,14 +211,15 @@ public class OrderServiceTests
         // Arrange
         var orderId = 1;
 
-        _orderRepositoryMock.Setup(o => o.FirstOrDefaultAsync(It.IsAny<EntityByIdSpec<Order>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((Order?)null);
+        _orderRepository.FirstOrDefaultAsync(Arg.Any<EntityByIdSpec<Order>>(), Arg.Any<CancellationToken>())
+            .Returns((Order?)null);
 
         // Act
         var result = await _orderService.RemoveOrderAsync(orderId, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(result);
-        _orderRepositoryMock.Verify(o => o.FirstOrDefaultAsync(It.IsAny<EntityByIdSpec<Order>>(), It.IsAny<CancellationToken>()));
+        await _orderRepository.Received(1).FirstOrDefaultAsync(Arg.Any<EntityByIdSpec<Order>>(), Arg.Any<CancellationToken>());
+        await _orderRepository.DidNotReceive().RemoveAsync(Arg.Any<Order>(), Arg.Any<CancellationToken>());
     }
 }

--- a/test/UnitTests/Core/Services/OrderServiceTests.cs
+++ b/test/UnitTests/Core/Services/OrderServiceTests.cs
@@ -9,17 +9,16 @@ using MoneyGroup.Core.Specifications;
 
 using Moq;
 
-namespace MoneyGroup.UnitTests.Services;
+namespace MoneyGroup.UnitTests.Core.Services;
 
-public class OrderServiceTest
+[Trait("Category", "Unit")]
+public class OrderServiceTests
 {
     private readonly Mock<IUserRepository> _userRepositoryMock;
     private readonly Mock<IOrderRepository> _orderRepositoryMock;
-#pragma warning disable CA1859 // Use concrete types when possible for improved performance
-    private readonly IOrderService _orderService;
-#pragma warning restore CA1859 // Use concrete types when possible for improved performance
+    private readonly OrderService _orderService;
 
-    public OrderServiceTest()
+    public OrderServiceTests()
     {
         _userRepositoryMock = new Mock<IUserRepository>();
         _orderRepositoryMock = new Mock<IOrderRepository>();

--- a/test/UnitTests/Core/Services/OrderServiceTests.cs
+++ b/test/UnitTests/Core/Services/OrderServiceTests.cs
@@ -2,6 +2,7 @@ using MoneyGroup.Core.Abstractions;
 using MoneyGroup.Core.Entities;
 using MoneyGroup.Core.Exceptions;
 using MoneyGroup.Core.Models.Orders;
+using MoneyGroup.Core.Models.Paginations;
 using MoneyGroup.Core.Services;
 using MoneyGroup.Core.Specifications;
 using MoneyGroup.UnitTests.Builders;
@@ -194,5 +195,46 @@ public class OrderServiceTests
         Assert.False(result);
         await _orderRepository.Received(1).FirstOrDefaultAsync(Arg.Any<EntityByIdSpec<Order>>(), Arg.Any<CancellationToken>());
         await _orderRepository.DidNotReceive().RemoveAsync(Arg.Any<Order>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GivenPagingOptions_WhenOrdersExist_ThenReturnsPaginatedOrders()
+    {
+        // Arrange
+        var options = new OrderPaginatedOptions(null, null, null, null, 1, 10);
+        var expected = new PaginatedModel<OrderDetailedDto>
+        {
+            Page = 1,
+            Count = 1,
+            Total = 1,
+            Items = [new OrderDetailedDto { Id = 1, Title = "Order 1" }],
+        };
+
+        _orderRepository.GetByPageAsync<OrderDetailedDto>(Arg.Any<OrderPaginatedSpec>(), Arg.Any<CancellationToken>())
+            .Returns(expected);
+
+        // Act
+        var result = await _orderService.GetOrdersByPageAsync(options);
+
+        // Assert
+        Assert.Same(expected, result);
+    }
+
+    [Fact]
+    public async Task GivenPagingOptions_WhenCalled_ThenPassesSpecificationBuiltFromOptions()
+    {
+        // Arrange
+        var options = new OrderPaginatedOptions(buyerId: 4, null, null, null, page: 3, size: 7);
+
+        _orderRepository.GetByPageAsync<OrderDetailedDto>(Arg.Any<OrderPaginatedSpec>(), Arg.Any<CancellationToken>())
+            .Returns(new PaginatedModel<OrderDetailedDto> { Page = 3, Count = 0, Total = 0, Items = [] });
+
+        // Act
+        await _orderService.GetOrdersByPageAsync(options);
+
+        // Assert
+        await _orderRepository.Received(1).GetByPageAsync<OrderDetailedDto>(
+            Arg.Is<OrderPaginatedSpec>(spec => spec.Skip == 14 && spec.Take == 7),
+            Arg.Any<CancellationToken>());
     }
 }

--- a/test/UnitTests/Core/Services/OrderServiceTests.cs
+++ b/test/UnitTests/Core/Services/OrderServiceTests.cs
@@ -22,7 +22,7 @@ public class OrderServiceTests
     }
 
     [Fact]
-    public async Task GetOrderByIdAsync_ValidId_ShouldReturnOrder()
+    public async Task GivenOrderId_WhenOrderExists_ThenReturnsOrder()
     {
         // Arrange
         var id = 1;
@@ -44,7 +44,7 @@ public class OrderServiceTests
     }
 
     [Fact]
-    public async Task GetOrderByIdAsync_InvalidId_ShouldReturnNull()
+    public async Task GivenOrderId_WhenOrderMissing_ThenReturnsNull()
     {
         // Arrange
         var invalidId = -1;
@@ -64,7 +64,7 @@ public class OrderServiceTests
     }
 
     [Fact]
-    public async Task CreateOrderAsync_ValidDto_ShouldAddOrder()
+    public async Task GivenOrder_WhenBuyerAndParticipantsExist_ThenAddsOrder()
     {
         // Arrange
         var newOrderId = 1;
@@ -100,7 +100,7 @@ public class OrderServiceTests
     }
 
     [Fact]
-    public async Task CreateOrderAsync_NoParticipants_ShouldAddOrder()
+    public async Task GivenOrder_WhenNoParticipants_ThenAddsOrderWithoutCountingParticipants()
     {
         // Arrange
         var newOrderId = 1;
@@ -130,7 +130,7 @@ public class OrderServiceTests
     }
 
     [Fact]
-    public async Task CreateOrderAsync_InvalidBuyer_ShouldThrowInvalidOperationException()
+    public async Task GivenOrder_WhenBuyerMissing_ThenThrowsBuyerNotFound()
     {
         // Arrange
         var model = new OrderDto
@@ -157,7 +157,7 @@ public class OrderServiceTests
     }
 
     [Fact]
-    public async Task CreateOrderAsync_InvalidParticipants_ShouldThrowInvalidOperationException()
+    public async Task GivenOrder_WhenAnyParticipantMissing_ThenThrowsParticipantNotFound()
     {
         // Arrange
         var model = new OrderDto
@@ -187,7 +187,7 @@ public class OrderServiceTests
     }
 
     [Fact]
-    public async Task RemoveOrderAsync_OrderExists_ShouldRemoveOrder()
+    public async Task GivenOrderId_WhenOrderExists_ThenRemovesOrderAndReturnsTrue()
     {
         // Arrange
         var orderId = 1;
@@ -206,7 +206,7 @@ public class OrderServiceTests
     }
 
     [Fact]
-    public async Task RemoveOrderAsync_OrderNotFound_ShouldThrowInvalidOperationException()
+    public async Task GivenOrderId_WhenOrderMissing_ThenReturnsFalse()
     {
         // Arrange
         var orderId = 1;

--- a/test/UnitTests/Core/Services/OrderServiceTests.cs
+++ b/test/UnitTests/Core/Services/OrderServiceTests.cs
@@ -4,6 +4,7 @@ using MoneyGroup.Core.Exceptions;
 using MoneyGroup.Core.Models.Orders;
 using MoneyGroup.Core.Services;
 using MoneyGroup.Core.Specifications;
+using MoneyGroup.UnitTests.Builders;
 
 using NSubstitute;
 
@@ -68,15 +69,7 @@ public class OrderServiceTests
     {
         // Arrange
         var newOrderId = 1;
-        var model = new OrderDto
-        {
-            BuyerId = 1,
-            Participants =
-            [
-                new() { ParticipantId = 2 },
-                new() { ParticipantId = 3 },
-            ],
-        };
+        var model = OrderDtoBuilder.Valid().WithBuyer(1).WithParticipants(2, 3).Build();
 
         _userRepository.AnyAsync(Arg.Any<EntityByIdSpec<User>>(), Arg.Any<CancellationToken>())
             .Returns(true);
@@ -104,11 +97,7 @@ public class OrderServiceTests
     {
         // Arrange
         var newOrderId = 1;
-        var model = new OrderDto
-        {
-            BuyerId = 1,
-            Participants = [],
-        };
+        var model = OrderDtoBuilder.Valid().WithBuyer(1).WithNoParticipants().Build();
 
         _userRepository.AnyAsync(Arg.Any<EntityByIdSpec<User>>(), Arg.Any<CancellationToken>())
             .Returns(true);
@@ -133,15 +122,7 @@ public class OrderServiceTests
     public async Task GivenOrder_WhenBuyerMissing_ThenThrowsBuyerNotFound()
     {
         // Arrange
-        var model = new OrderDto
-        {
-            BuyerId = -1,
-            Participants =
-            [
-                new() { ParticipantId = 2 },
-                new() { ParticipantId = 3 },
-            ],
-        };
+        var model = OrderDtoBuilder.Valid().WithBuyer(-1).WithParticipants(2, 3).Build();
 
         _userRepository.AnyAsync(Arg.Any<EntityByIdSpec<User>>(), Arg.Any<CancellationToken>())
             .Returns(false);
@@ -160,15 +141,7 @@ public class OrderServiceTests
     public async Task GivenOrder_WhenAnyParticipantMissing_ThenThrowsParticipantNotFound()
     {
         // Arrange
-        var model = new OrderDto
-        {
-            BuyerId = 1,
-            Participants =
-            [
-                new() { ParticipantId = 2 },
-                new() { ParticipantId = -1 },
-            ],
-        };
+        var model = OrderDtoBuilder.Valid().WithBuyer(1).WithParticipants(2, -1).Build();
 
         _userRepository.AnyAsync(Arg.Any<EntityByIdSpec<User>>(), Arg.Any<CancellationToken>())
             .Returns(true);

--- a/test/UnitTests/Core/Services/UserServiceTests.cs
+++ b/test/UnitTests/Core/Services/UserServiceTests.cs
@@ -1,0 +1,141 @@
+using MoneyGroup.Core.Abstractions;
+using MoneyGroup.Core.Entities;
+using MoneyGroup.Core.Models.Paginations;
+using MoneyGroup.Core.Models.Users;
+using MoneyGroup.Core.Services;
+using MoneyGroup.Core.Specifications;
+using MoneyGroup.UnitTests.Builders;
+
+using NSubstitute;
+
+namespace MoneyGroup.UnitTests.Core.Services;
+
+[Trait("Category", "Unit")]
+public class UserServiceTests
+{
+    private readonly IUserRepository _userRepository = Substitute.For<IUserRepository>();
+    private readonly UserService _userService;
+
+    public UserServiceTests()
+    {
+        _userService = new UserService(_userRepository);
+    }
+
+    [Fact]
+    public async Task GivenUserId_WhenUserExists_ThenReturnsUser()
+    {
+        // Arrange
+        var user = UserDtoBuilder.Valid().WithId(7).Build();
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        _userRepository.FirstOrDefaultAsync<UserDto>(Arg.Any<EntityByIdSpec<User>>(), cancellationToken)
+            .Returns(user);
+
+        // Act
+        var result = await _userService.GetUserByIdAsync(7, cancellationToken);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(7, result.Id);
+        await _userRepository.Received(1)
+            .FirstOrDefaultAsync<UserDto>(Arg.Any<EntityByIdSpec<User>>(), cancellationToken);
+    }
+
+    [Fact]
+    public async Task GivenUserId_WhenUserMissing_ThenReturnsNull()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        _userRepository.FirstOrDefaultAsync<UserDto>(Arg.Any<EntityByIdSpec<User>>(), cancellationToken)
+            .Returns((UserDto?)null);
+
+        // Act
+        var result = await _userService.GetUserByIdAsync(int.MaxValue, cancellationToken);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GivenEmail_WhenUserExists_ThenReturnsUser()
+    {
+        // Arrange
+        var user = UserDtoBuilder.Valid().WithEmail("known@domain.com").Build();
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        _userRepository.FirstOrDefaultAsync<UserDto>(Arg.Any<UserByEmailSpec>(), cancellationToken)
+            .Returns(user);
+
+        // Act
+        var result = await _userService.GetUserByEmailAsync("known@domain.com", cancellationToken);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("known@domain.com", result.Email);
+        await _userRepository.Received(1)
+            .FirstOrDefaultAsync<UserDto>(Arg.Any<UserByEmailSpec>(), cancellationToken);
+    }
+
+    [Fact]
+    public async Task GivenEmail_WhenUserMissing_ThenReturnsNull()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        _userRepository.FirstOrDefaultAsync<UserDto>(Arg.Any<UserByEmailSpec>(), cancellationToken)
+            .Returns((UserDto?)null);
+
+        // Act
+        var result = await _userService.GetUserByEmailAsync("absent@domain.com", cancellationToken);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GivenPagingOptions_WhenUsersExist_ThenReturnsPaginatedUsers()
+    {
+        // Arrange
+        var options = new UserPaginatedOptions(page: 1, size: 10);
+        var expected = new PaginatedModel<UserDto>
+        {
+            Page = 1,
+            Count = 1,
+            Total = 1,
+            Items = [UserDtoBuilder.Valid().Build()],
+        };
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        _userRepository.GetByPageAsync<UserDto>(Arg.Any<UserPaginatedSpec>(), cancellationToken)
+            .Returns(expected);
+
+        // Act
+        var result = await _userService.GetUsersByPageAsync(options, cancellationToken);
+
+        // Assert
+        Assert.Same(expected, result);
+        await _userRepository.Received(1)
+            .GetByPageAsync<UserDto>(Arg.Any<UserPaginatedSpec>(), cancellationToken);
+    }
+
+    [Fact]
+    public async Task GivenPagingOptions_WhenKeywordSupplied_ThenPassesSpecificationBuiltFromOptions()
+    {
+        // Arrange
+        var options = new UserPaginatedOptions(page: 2, size: 5) { Keyword = "ruong" };
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        _userRepository.GetByPageAsync<UserDto>(Arg.Any<UserPaginatedSpec>(), cancellationToken)
+            .Returns(new PaginatedModel<UserDto> { Page = 2, Count = 0, Total = 0, Items = [] });
+
+        // Act
+        await _userService.GetUsersByPageAsync(options, cancellationToken);
+
+        // Assert
+        await _userRepository.Received(1).GetByPageAsync<UserDto>(
+            Arg.Is<UserPaginatedSpec>(spec =>
+                spec.PaginatedOptions.Page == 2 && spec.PaginatedOptions.Size == 5),
+            cancellationToken);
+    }
+}

--- a/test/UnitTests/Core/Specifications/SpecificationTests.cs
+++ b/test/UnitTests/Core/Specifications/SpecificationTests.cs
@@ -1,0 +1,190 @@
+using MoneyGroup.Core.Entities;
+using MoneyGroup.Core.Models.Orders;
+using MoneyGroup.Core.Models.Paginations;
+using MoneyGroup.Core.Models.Users;
+using MoneyGroup.Core.Specifications;
+
+namespace MoneyGroup.UnitTests.Core.Specifications;
+
+[Trait("Category", "Unit")]
+public class SpecificationTests
+{
+    private static Order Order(int id, int buyerId = 1, decimal total = 100, params int[] participantIds) => new()
+    {
+        Id = id,
+        Title = $"Order {id}",
+        BuyerId = buyerId,
+        Total = total,
+        Participants = [.. participantIds.Select(p => new OrderParticipant { ParticipantId = p, OrderId = id })],
+    };
+
+    [Fact]
+    public void GivenEntityByIdSpec_WhenIdMatches_ThenIsSatisfied()
+    {
+        var spec = new EntityByIdSpec<Order>(5);
+
+        Assert.True(spec.IsSatisfiedBy(Order(5)));
+        Assert.False(spec.IsSatisfiedBy(Order(6)));
+    }
+
+    [Fact]
+    public void GivenEntityByIdsSpec_WhenIdInSet_ThenIsSatisfied()
+    {
+        var spec = new EntityByIdsSpec<User>([1, 3]);
+
+        Assert.True(spec.IsSatisfiedBy(new User { Id = 1, Name = "A" }));
+        Assert.True(spec.IsSatisfiedBy(new User { Id = 3, Name = "C" }));
+        Assert.False(spec.IsSatisfiedBy(new User { Id = 2, Name = "B" }));
+    }
+
+    [Fact]
+    public void GivenEntityByIdsSpec_WhenIdsEmpty_ThenNothingIsSatisfied()
+    {
+        var spec = new EntityByIdsSpec<User>([]);
+
+        Assert.False(spec.IsSatisfiedBy(new User { Id = 1, Name = "A" }));
+    }
+
+    [Fact]
+    public void GivenUserByEmailSpec_WhenEmailMatches_ThenIsSatisfied()
+    {
+        var spec = new UserByEmailSpec("a@b.com");
+
+        Assert.True(spec.IsSatisfiedBy(new User { Id = 1, Name = "A", Email = "a@b.com" }));
+        Assert.False(spec.IsSatisfiedBy(new User { Id = 2, Name = "B", Email = "other@b.com" }));
+        Assert.False(spec.IsSatisfiedBy(new User { Id = 3, Name = "C", Email = null }));
+    }
+
+    [Fact]
+    public void GivenBasePaginatedSpec_WhenFirstPage_ThenSkipsNoneAndTakesPageSize()
+    {
+        var spec = new BasePaginatedSpecification<User>(new PaginatedOptions(page: 1, size: 3));
+
+        Assert.Equal(0, spec.Skip);
+        Assert.Equal(3, spec.Take);
+    }
+
+    [Fact]
+    public void GivenBasePaginatedSpec_WhenThirdPage_ThenSkipsTwoPages()
+    {
+        var spec = new BasePaginatedSpecification<User>(new PaginatedOptions(page: 3, size: 10));
+
+        Assert.Equal(20, spec.Skip);
+        Assert.Equal(10, spec.Take);
+    }
+
+    [Fact]
+    public void GivenBasePaginatedSpec_WhenEvaluated_ThenReturnsRequestedWindow()
+    {
+        var users = Enumerable.Range(1, 10)
+            .Select(i => new User { Id = i, Name = $"U{i}" })
+            .ToList();
+        var spec = new BasePaginatedSpecification<User>(new PaginatedOptions(page: 2, size: 3));
+
+        var result = spec.Evaluate(users).ToList();
+
+        Assert.Equal(3, result.Count);
+        Assert.Equal([4, 5, 6], result.Select(u => u.Id));
+    }
+
+    [Fact]
+    public void GivenUserPaginatedSpec_WhenKeywordSupplied_ThenFiltersByNameContains()
+    {
+        var users = new List<User>
+        {
+            new() { Id = 1, Name = "Truong" },
+            new() { Id = 2, Name = "Duc" },
+            new() { Id = 3, Name = "Manh" },
+        };
+        var spec = new UserPaginatedSpec(new UserPaginatedOptions(1, 10) { Keyword = "ruo" });
+
+        var result = spec.Evaluate(users).ToList();
+
+        Assert.Equal([1], result.Select(u => u.Id));
+    }
+
+    [Fact]
+    public void GivenUserPaginatedSpec_WhenKeywordBlank_ThenReturnsEveryone()
+    {
+        var users = new List<User>
+        {
+            new() { Id = 1, Name = "Truong" },
+            new() { Id = 2, Name = "Duc" },
+        };
+        var spec = new UserPaginatedSpec(new UserPaginatedOptions(1, 10) { Keyword = "   " });
+
+        var result = spec.Evaluate(users).ToList();
+
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public void GivenOrderPaginatedSpec_WhenNoFilters_ThenOrdersByIdDescending()
+    {
+        var orders = new List<Order> { Order(1), Order(3), Order(2) };
+        var spec = new OrderPaginatedSpec(new OrderPaginatedOptions(null, null, null, null, 1, 10));
+
+        var result = spec.Evaluate(orders).ToList();
+
+        Assert.Equal([3, 2, 1], result.Select(o => o.Id));
+    }
+
+    [Fact]
+    public void GivenOrderPaginatedSpec_WhenBuyerIdSupplied_ThenFiltersByBuyer()
+    {
+        var orders = new List<Order> { Order(1, buyerId: 1), Order(2, buyerId: 2) };
+        var spec = new OrderPaginatedSpec(new OrderPaginatedOptions(2, null, null, null, 1, 10));
+
+        var result = spec.Evaluate(orders).ToList();
+
+        Assert.Equal([2], result.Select(o => o.Id));
+    }
+
+    [Fact]
+    public void GivenOrderPaginatedSpec_WhenParticipantIdSupplied_ThenFiltersByParticipant()
+    {
+        var orders = new List<Order>
+        {
+            Order(1, participantIds: [1, 2]),
+            Order(2, participantIds: [3]),
+        };
+        var spec = new OrderPaginatedSpec(new OrderPaginatedOptions(null, 3, null, null, 1, 10));
+
+        var result = spec.Evaluate(orders).ToList();
+
+        Assert.Equal([2], result.Select(o => o.Id));
+    }
+
+    [Fact]
+    public void GivenOrderPaginatedSpec_WhenTotalBoundsSupplied_ThenFiltersInclusively()
+    {
+        var orders = new List<Order>
+        {
+            Order(1, total: 50),
+            Order(2, total: 100),
+            Order(3, total: 150),
+        };
+        var spec = new OrderPaginatedSpec(new OrderPaginatedOptions(null, null, 150m, 100m, 1, 10));
+
+        var result = spec.Evaluate(orders).ToList();
+
+        Assert.Equal([3, 2], result.Select(o => o.Id));
+    }
+
+    [Fact]
+    public void GivenOrderPaginatedSpec_WhenAllFiltersCombined_ThenAppliesEveryFilter()
+    {
+        var orders = new List<Order>
+        {
+            Order(1, buyerId: 1, total: 100, participantIds: [1]),
+            Order(2, buyerId: 1, total: 500, participantIds: [1]),
+            Order(3, buyerId: 2, total: 100, participantIds: [1]),
+            Order(4, buyerId: 1, total: 100, participantIds: [9]),
+        };
+        var spec = new OrderPaginatedSpec(new OrderPaginatedOptions(1, 1, 200m, 50m, 1, 10));
+
+        var result = spec.Evaluate(orders).ToList();
+
+        Assert.Equal([1], result.Select(o => o.Id));
+    }
+}

--- a/test/UnitTests/Infrastructure/Mapperly/MapperTests.cs
+++ b/test/UnitTests/Infrastructure/Mapperly/MapperTests.cs
@@ -1,0 +1,134 @@
+using MoneyGroup.Core.Entities;
+using MoneyGroup.Core.Models.Orders;
+using MoneyGroup.Core.Models.Users;
+using MoneyGroup.Infrastructure.Mapperly;
+using MoneyGroup.UnitTests.Builders;
+
+namespace MoneyGroup.UnitTests.Infrastructure.Mapperly;
+
+[Trait("Category", "Unit")]
+public class MapperTests
+{
+    private readonly Mapper _mapper = new();
+
+    [Fact]
+    public void GivenParticipantDto_WhenMapped_ThenCopiesParticipantId()
+    {
+        // Arrange
+        var dto = new ParticipantDto { ParticipantId = 42 };
+
+        // Act
+        var entity = _mapper.Map(dto);
+
+        // Assert
+        Assert.Equal(42, entity.ParticipantId);
+    }
+
+    [Fact]
+    public void GivenOrderDto_WhenMapped_ThenCopiesEveryScalarField()
+    {
+        // Arrange
+        var dto = OrderDtoBuilder.Valid()
+            .WithId(7)
+            .WithTitle("Dinner")
+            .WithDescription("Team dinner")
+            .WithTotal(1234.56m)
+            .WithBuyer(3)
+            .WithParticipants(1, 2)
+            .Build();
+
+        // Act
+        var entity = _mapper.Map(dto);
+
+        // Assert
+        Assert.Equal(7, entity.Id);
+        Assert.Equal("Dinner", entity.Title);
+        Assert.Equal("Team dinner", entity.Description);
+        Assert.Equal(1234.56m, entity.Total);
+        Assert.Equal(3, entity.BuyerId);
+        Assert.Equal([1, 2], entity.Participants.Select(p => p.ParticipantId));
+    }
+
+    [Fact]
+    public void GivenOrderDto_WhenMapped_ThenLeavesBuyerNavigationUnset()
+    {
+        // Arrange
+        var dto = OrderDtoBuilder.Valid().WithBuyer(3).Build();
+
+        // Act
+        var entity = _mapper.Map(dto);
+
+        // Assert
+        Assert.Null(entity.Buyer);
+    }
+
+    [Fact]
+    public void GivenOrderParticipant_WhenMapped_ThenFlattensParticipantName()
+    {
+        // Arrange
+        var entity = new OrderParticipant
+        {
+            ParticipantId = 5,
+            Participant = new User { Id = 5, Name = "Manh" },
+        };
+
+        // Act
+        var dto = _mapper.Map(entity);
+
+        // Assert
+        Assert.Equal(5, dto.ParticipantId);
+        Assert.Equal("Manh", dto.ParticipantName);
+    }
+
+    [Fact]
+    public void GivenOrder_WhenMapped_ThenFlattensBuyerName()
+    {
+        // Arrange
+        var entity = new Order
+        {
+            Id = 1,
+            Title = "Order 1",
+            Description = "desc",
+            Total = 10_000m,
+            BuyerId = 1,
+            Buyer = new User { Id = 1, Name = "Truong" },
+            Participants =
+            [
+                new() { ParticipantId = 2, Participant = new User { Id = 2, Name = "Duc" } },
+            ],
+        };
+
+        // Act
+        var dto = _mapper.Map(entity);
+
+        // Assert
+        Assert.Equal(1, dto.Id);
+        Assert.Equal("Order 1", dto.Title);
+        Assert.Equal(10_000m, dto.Total);
+        Assert.Equal("Truong", dto.BuyerName);
+        var participant = Assert.Single(dto.Participants);
+        Assert.Equal(2, participant.ParticipantId);
+        Assert.Equal("Duc", participant.ParticipantName);
+    }
+
+    [Fact]
+    public void GivenUserQueryable_WhenProjected_ThenMapsIdNameAndEmail()
+    {
+        // Arrange
+        var users = new List<User>
+        {
+            new() { Id = 1, Name = "Truong", Email = "t@d.com" },
+            new() { Id = 2, Name = "Duc", Email = null },
+        }.AsQueryable();
+
+        // Act
+        var projected = _mapper.Project(users).ToList();
+
+        // Assert
+        Assert.Equal(2, projected.Count);
+        Assert.Equal([1, 2], projected.Select(u => u.Id));
+        Assert.Equal(["Truong", "Duc"], projected.Select(u => u.Name));
+        Assert.Equal("t@d.com", projected[0].Email);
+        Assert.Null(projected[1].Email);
+    }
+}

--- a/test/UnitTests/MoneyGroup.UnitTests.csproj
+++ b/test/UnitTests/MoneyGroup.UnitTests.csproj
@@ -14,7 +14,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
-    <PackageReference Include="Moq" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="xunit.v3.mtp-v2" />
   </ItemGroup>

--- a/test/UnitTests/MoneyGroup.UnitTests.csproj
+++ b/test/UnitTests/MoneyGroup.UnitTests.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Moq" />
+    <PackageReference Include="NSubstitute" />
     <PackageReference Include="xunit.v3.mtp-v2" />
   </ItemGroup>
 

--- a/test/UnitTests/MoneyGroup.UnitTests.csproj
+++ b/test/UnitTests/MoneyGroup.UnitTests.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Core\MoneyGroup.Core.csproj" />
+    <ProjectReference Include="..\..\src\WebApi\MoneyGroup.WebApi.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/UnitTests/WebApi/Authorizations/DenyUnauthorizedUserHandlerTests.cs
+++ b/test/UnitTests/WebApi/Authorizations/DenyUnauthorizedUserHandlerTests.cs
@@ -11,16 +11,17 @@ using MoneyGroup.WebApi.Authorizations;
 
 using Moq;
 
-namespace MoneyGroup.FunctionalTests.Authorizations;
+namespace MoneyGroup.UnitTests.WebApi.Authorizations;
 
-public class DenyUnauthorizedUserHandlerTest
+[Trait("Category", "Unit")]
+public class DenyUnauthorizedUserHandlerTests
 {
     private readonly Mock<IUserService> _userServiceMock;
     private readonly Mock<ClaimsPrincipal> _userMock;
     private readonly DenyUnauthorizedUserHandler _handler;
     private readonly AuthorizationHandlerContext _authContext;
 
-    public DenyUnauthorizedUserHandlerTest()
+    public DenyUnauthorizedUserHandlerTests()
     {
         var requirement = new DenyUnauthorizedUserRequirement();
         _userServiceMock = new();

--- a/test/UnitTests/WebApi/Authorizations/DenyUnauthorizedUserHandlerTests.cs
+++ b/test/UnitTests/WebApi/Authorizations/DenyUnauthorizedUserHandlerTests.cs
@@ -1,116 +1,115 @@
-﻿using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.IdentityModel.JsonWebTokens;
 
 using MoneyGroup.Core.Abstractions;
 using MoneyGroup.Core.Models.Users;
 using MoneyGroup.WebApi.Authorizations;
 
-using Moq;
+using NSubstitute;
 
 namespace MoneyGroup.UnitTests.WebApi.Authorizations;
 
 [Trait("Category", "Unit")]
 public class DenyUnauthorizedUserHandlerTests
 {
-    private readonly Mock<IUserService> _userServiceMock;
-    private readonly Mock<ClaimsPrincipal> _userMock;
+    private const string Email = "user@domain.com";
+
+    private readonly IUserService _userService = Substitute.For<IUserService>();
     private readonly DenyUnauthorizedUserHandler _handler;
-    private readonly AuthorizationHandlerContext _authContext;
 
     public DenyUnauthorizedUserHandlerTests()
     {
-        var requirement = new DenyUnauthorizedUserRequirement();
-        _userServiceMock = new();
-        _userMock = new();
-        _authContext = new AuthorizationHandlerContext([requirement], _userMock.Object, resource: null);
-        _handler = new DenyUnauthorizedUserHandler(NullLoggerFactory.Instance.CreateLogger<DenyUnauthorizedUserHandler>(), _userServiceMock.Object);
+        _handler = new DenyUnauthorizedUserHandler(
+            NullLoggerFactory.Instance.CreateLogger<DenyUnauthorizedUserHandler>(),
+            _userService);
+    }
 
+    private static AuthorizationHandlerContext ContextFor(ClaimsPrincipal user) =>
+        new([new DenyUnauthorizedUserRequirement()], user, resource: null);
+
+    private static ClaimsPrincipal Anonymous() => new(new ClaimsIdentity());
+
+    private static ClaimsPrincipal Authenticated(params Claim[] claims) =>
+        new(new ClaimsIdentity(claims, authenticationType: "TestAuth"));
+
+    [Fact]
+    public async Task GivenUser_WhenNotAuthenticated_ThenDoesNotSucceed()
+    {
+        // Arrange
+        var context = ContextFor(Anonymous());
+
+        // Act
+        await _handler.HandleAsync(context);
+
+        // Assert
+        Assert.False(context.HasSucceeded);
     }
 
     [Fact]
-    public async Task HandleAsync_WhenUserIsNotAuthenticated_ShouldReturnUnauthorized()
+    public async Task GivenUser_WhenEmailClaimMissing_ThenDoesNotSucceed()
     {
         // Arrange
-        _userMock.Setup(u => u.Identity!.IsAuthenticated).Returns(false);
+        var context = ContextFor(Authenticated());
 
         // Act
-        await _handler.HandleAsync(_authContext);
+        await _handler.HandleAsync(context);
 
         // Assert
-        Assert.False(_authContext.HasSucceeded);
+        Assert.False(context.HasSucceeded);
     }
 
     [Fact]
-    public async Task HandleAsync_WhenUserEmailIsNotPresent_ShouldReturnUnauthorized()
+    public async Task GivenUser_WhenEmailVerifiedClaimMissing_ThenDoesNotSucceed()
     {
         // Arrange
-        _userMock.Setup(u => u.Identity!.IsAuthenticated).Returns(true);
-        _userMock.Setup(u => u.FindFirst(ClaimTypes.Email)).Returns((Claim?)null);
+        var context = ContextFor(Authenticated(new Claim(ClaimTypes.Email, Email)));
 
         // Act
-        await _handler.HandleAsync(_authContext);
+        await _handler.HandleAsync(context);
 
         // Assert
-        Assert.False(_authContext.HasSucceeded);
-
+        Assert.False(context.HasSucceeded);
     }
 
     [Fact]
-    public async Task HandleAsync_WhenUserEmailIsNotValid_ShouldReturnUnauthorized()
+    public async Task GivenVerifiedEmail_WhenUserNotFound_ThenDoesNotSucceed()
     {
         // Arrange
-        _userMock.Setup(u => u.Identity!.IsAuthenticated).Returns(true);
-        _userMock.Setup(u => u.FindFirst(ClaimTypes.Email)).Returns(EmailClaim);
-        _userMock.Setup(u => u.FindFirst(JwtRegisteredClaimNames.EmailVerified)).Returns((Claim?)null);
+        var context = ContextFor(Authenticated(
+            new Claim(ClaimTypes.Email, Email),
+            new Claim(JwtRegisteredClaimNames.EmailVerified, "true")));
+
+        _userService.GetUserByEmailAsync(Email, Arg.Any<CancellationToken>())
+            .Returns((UserDto?)null);
 
         // Act
-        await _handler.HandleAsync(_authContext);
+        await _handler.HandleAsync(context);
 
         // Assert
-        Assert.False(_authContext.HasSucceeded);
-    }
-
-    private const string Email = "user@domain.com";
-    private static readonly Claim EmailClaim = new(ClaimTypes.Email, Email);
-
-    [Fact]
-    public async Task HandlerAsync_WhenUserNotFound_ShouldReturnUnauthorized()
-    {
-        // Arrange
-        _userMock.Setup(u => u.Identity!.IsAuthenticated).Returns(true);
-        _userMock.Setup(u => u.FindFirst(ClaimTypes.Email)).Returns(EmailClaim);
-        _userMock.Setup(u => u.FindFirst(JwtRegisteredClaimNames.EmailVerified)).Returns(new Claim(JwtRegisteredClaimNames.EmailVerified, "true"));
-        _userServiceMock.Setup(r => r.GetUserByEmailAsync(It.IsAny<string>(), CancellationToken.None)).ReturnsAsync((UserDto?)null);
-
-        // Act
-        await _handler.HandleAsync(_authContext);
-
-        // Assert
-        Assert.False(_authContext.HasSucceeded);
+        Assert.False(context.HasSucceeded);
+        await _userService.Received(1).GetUserByEmailAsync(Email, Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task HandlerAsync_WhenUserFound_ShouldReturnOk()
+    public async Task GivenVerifiedEmail_WhenUserFound_ThenSucceeds()
     {
         // Arrange
-        _userMock.Setup(u => u.Identity!.IsAuthenticated).Returns(true);
-        _userMock.Setup(u => u.FindFirst(ClaimTypes.Email)).Returns(EmailClaim);
-        _userMock.Setup(u => u.FindFirst(JwtRegisteredClaimNames.EmailVerified)).Returns(new Claim(JwtRegisteredClaimNames.EmailVerified, "true"));
-        _userServiceMock.Setup(r => r.GetUserByEmailAsync(It.IsAny<string>(), CancellationToken.None)).ReturnsAsync(new UserDto()
-        {
-            Id = 1,
-            Name = "User",
-            Email = Email,
-        });
+        var context = ContextFor(Authenticated(
+            new Claim(ClaimTypes.Email, Email),
+            new Claim(JwtRegisteredClaimNames.EmailVerified, "true")));
+
+        _userService.GetUserByEmailAsync(Email, Arg.Any<CancellationToken>())
+            .Returns(new UserDto { Id = 1, Name = "User", Email = Email });
 
         // Act
-        await _handler.HandleAsync(_authContext);
+        await _handler.HandleAsync(context);
 
         // Assert
-        Assert.True(_authContext.HasSucceeded);
+        Assert.True(context.HasSucceeded);
+        await _userService.Received(1).GetUserByEmailAsync(Email, Arg.Any<CancellationToken>());
     }
 }

--- a/test/UnitTests/WebApi/Endpoints/OrderEndpointsTests.cs
+++ b/test/UnitTests/WebApi/Endpoints/OrderEndpointsTests.cs
@@ -1,0 +1,114 @@
+using Microsoft.AspNetCore.Http.HttpResults;
+
+using MoneyGroup.Core.Abstractions;
+using MoneyGroup.Core.Models.Orders;
+using MoneyGroup.Core.Models.Paginations;
+using MoneyGroup.UnitTests.Builders;
+using MoneyGroup.WebApi.Endpoints;
+
+using NSubstitute;
+
+namespace MoneyGroup.UnitTests.WebApi.Endpoints;
+
+[Trait("Category", "Unit")]
+public class OrderEndpointsTests
+{
+    private readonly IOrderService _orderService = Substitute.For<IOrderService>();
+
+    [Fact]
+    public async Task GivenOrderId_WhenOrderExists_ThenReturnsOk()
+    {
+        // Arrange
+        var order = new OrderDetailedDto { Id = 1, Title = "Order 1" };
+        _orderService.GetOrderByIdAsync(1, Arg.Any<CancellationToken>()).Returns(order);
+
+        // Act
+        var result = await OrderEndpoints.GetOrderByIdAsync(1, _orderService);
+
+        // Assert
+        var ok = Assert.IsType<Ok<OrderDetailedDto>>(result.Result);
+        Assert.Same(order, ok.Value);
+    }
+
+    [Fact]
+    public async Task GivenOrderId_WhenOrderMissing_ThenReturnsNotFound()
+    {
+        // Arrange
+        _orderService.GetOrderByIdAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns((OrderDetailedDto?)null);
+
+        // Act
+        var result = await OrderEndpoints.GetOrderByIdAsync(int.MaxValue, _orderService);
+
+        // Assert
+        Assert.IsType<NotFound>(result.Result);
+    }
+
+    [Fact]
+    public async Task GivenOrderId_WhenOrderRemoved_ThenReturnsNoContent()
+    {
+        // Arrange
+        _orderService.RemoveOrderAsync(1, Arg.Any<CancellationToken>()).Returns(true);
+
+        // Act
+        var result = await OrderEndpoints.DeleteOrderAsync(1, _orderService, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.IsType<NoContent>(result.Result);
+    }
+
+    [Fact]
+    public async Task GivenOrderId_WhenNothingRemoved_ThenReturnsNotFound()
+    {
+        // Arrange
+        _orderService.RemoveOrderAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(false);
+
+        // Act
+        var result = await OrderEndpoints.DeleteOrderAsync(
+            int.MaxValue, _orderService, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.IsType<NotFound>(result.Result);
+    }
+
+    [Fact]
+    public async Task GivenOrder_WhenCreated_ThenReturnsCreatedAtRouteWithNewId()
+    {
+        // Arrange
+        var input = OrderDtoBuilder.Valid().WithBuyer(1).WithParticipants(1, 2).Build();
+        _orderService
+            .When(s => s.CreateOrderAsync(input, Arg.Any<CancellationToken>()))
+            .Do(_ => input.Id = 99);
+
+        // Act
+        var result = await OrderEndpoints.CreateOrderAsync(input, _orderService);
+
+        // Assert
+        var created = Assert.IsType<CreatedAtRoute<OrderDto>>(result.Result);
+        Assert.Same(input, created.Value);
+        Assert.Equal("GetOrderById", created.RouteName);
+        Assert.Equal(99, created.RouteValues["id"]);
+    }
+
+    [Fact]
+    public async Task GivenPagingRequest_WhenCalled_ThenReturnsOkWithServiceResult()
+    {
+        // Arrange
+        var request = new OrderPaginatedRequest(null, null, null, null, 1, 10);
+        var expected = new PaginatedModel<OrderDetailedDto>
+        {
+            Page = 1,
+            Count = 0,
+            Total = 0,
+            Items = [],
+        };
+        _orderService.GetOrdersByPageAsync(request).Returns(expected);
+
+        // Act
+        var result = await OrderEndpoints.GetOrdersAsync(request, _orderService);
+
+        // Assert
+        var ok = Assert.IsType<Ok<PaginatedModel<OrderDetailedDto>>>(result.Result);
+        Assert.Same(expected, ok.Value);
+    }
+}

--- a/test/UnitTests/WebApi/Endpoints/UserEndpointsTests.cs
+++ b/test/UnitTests/WebApi/Endpoints/UserEndpointsTests.cs
@@ -1,0 +1,91 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+using MoneyGroup.Core.Abstractions;
+using MoneyGroup.Core.Models.Paginations;
+using MoneyGroup.Core.Models.Users;
+using MoneyGroup.UnitTests.Builders;
+using MoneyGroup.WebApi.Endpoints;
+using MoneyGroup.WebApi.Features;
+
+using NSubstitute;
+
+namespace MoneyGroup.UnitTests.WebApi.Endpoints;
+
+[Trait("Category", "Unit")]
+public class UserEndpointsTests
+{
+    private readonly IUserService _userService = Substitute.For<IUserService>();
+
+    [Fact]
+    public async Task GivenUserId_WhenUserExists_ThenReturnsOk()
+    {
+        // Arrange
+        var user = UserDtoBuilder.Valid().WithId(1).Build();
+        _userService.GetUserByIdAsync(1, Arg.Any<CancellationToken>()).Returns(user);
+
+        // Act
+        var result = await UserEndpoints.GetUserByIdAsync(
+            1, _userService, TestContext.Current.CancellationToken);
+
+        // Assert
+        var ok = Assert.IsType<Ok<UserDto>>(result.Result);
+        Assert.Same(user, ok.Value);
+    }
+
+    [Fact]
+    public async Task GivenUserId_WhenUserMissing_ThenReturnsNotFound()
+    {
+        // Arrange
+        _userService.GetUserByIdAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns((UserDto?)null);
+
+        // Act
+        var result = await UserEndpoints.GetUserByIdAsync(
+            int.MaxValue, _userService, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.IsType<NotFound>(result.Result);
+    }
+
+    [Fact]
+    public async Task GivenPagingRequest_WhenCalled_ThenReturnsOkWithServiceResult()
+    {
+        // Arrange
+        var request = new UserPaginatedRequest(keyword: null, page: 1, size: 10);
+        var expected = new PaginatedModel<UserDto> { Page = 1, Count = 0, Total = 0, Items = [] };
+        _userService.GetUsersByPageAsync(request, Arg.Any<CancellationToken>()).Returns(expected);
+
+        // Act
+        var result = await UserEndpoints.GetUsersAsync(request, _userService);
+
+        // Assert
+        var ok = Assert.IsType<Ok<PaginatedModel<UserDto>>>(result.Result);
+        Assert.Same(expected, ok.Value);
+    }
+
+    [Fact]
+    public void GivenHttpContext_WhenCurrentUserFeaturePresent_ThenReturnsThatUser()
+    {
+        // Arrange
+        var user = UserDtoBuilder.Valid().WithId(5).Build();
+        var httpContext = new DefaultHttpContext();
+        httpContext.Features.Set<ICurrentUserFeature>(new CurrentUserFeature { User = user });
+
+        // Act
+        var result = UserEndpoints.GetExecutingUser(httpContext);
+
+        // Assert
+        Assert.Same(user, result.Value);
+    }
+
+    [Fact]
+    public void GivenHttpContext_WhenCurrentUserFeatureMissing_ThenThrowsArgumentNull()
+    {
+        // Arrange
+        var httpContext = new DefaultHttpContext();
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => UserEndpoints.GetExecutingUser(httpContext));
+    }
+}

--- a/test/UnitTests/WebApi/Middlewares/BusinessValidationExceptionHandlerTests.cs
+++ b/test/UnitTests/WebApi/Middlewares/BusinessValidationExceptionHandlerTests.cs
@@ -1,0 +1,82 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+using MoneyGroup.Core.Exceptions;
+using MoneyGroup.WebApi.Middlewares;
+
+using NSubstitute;
+
+namespace MoneyGroup.UnitTests.WebApi.Middlewares;
+
+[Trait("Category", "Unit")]
+public class BusinessValidationExceptionHandlerTests
+{
+    private readonly IProblemDetailsService _problemDetailsService = Substitute.For<IProblemDetailsService>();
+    private readonly BusinessValidationExceptionHandler _handler;
+
+    public BusinessValidationExceptionHandlerTests()
+    {
+        _handler = new BusinessValidationExceptionHandler(_problemDetailsService);
+    }
+
+    [Fact]
+    public async Task GivenUnrelatedException_WhenHandled_ThenReturnsFalseAndWritesNothing()
+    {
+        // Arrange
+        var httpContext = new DefaultHttpContext();
+
+        // Act
+        var handled = await _handler.TryHandleAsync(
+            httpContext, new InvalidOperationException("boom"), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(handled);
+        await _problemDetailsService.DidNotReceive().WriteAsync(Arg.Any<ProblemDetailsContext>());
+    }
+
+    [Fact]
+    public async Task GivenBuyerNotFound_WhenHandled_ThenReturnsTrue()
+    {
+        // Arrange
+        var httpContext = new DefaultHttpContext();
+
+        // Act
+        var handled = await _handler.TryHandleAsync(
+            httpContext, new BuyerNotFoundException(), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.True(handled);
+    }
+
+    [Fact]
+    public async Task GivenBuyerNotFound_WhenHandled_ThenSetsBadRequestStatus()
+    {
+        // Arrange
+        var httpContext = new DefaultHttpContext();
+
+        // Act
+        await _handler.TryHandleAsync(
+            httpContext, new BuyerNotFoundException(), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, httpContext.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GivenParticipantNotFound_WhenHandled_ThenWritesProblemDetailsCarryingTheMessage()
+    {
+        // Arrange
+        var httpContext = new DefaultHttpContext();
+        var exception = new ParticipantNotFoundException();
+
+        // Act
+        await _handler.TryHandleAsync(httpContext, exception, TestContext.Current.CancellationToken);
+
+        // Assert
+        await _problemDetailsService.Received(1).WriteAsync(
+            Arg.Is<ProblemDetailsContext>(ctx =>
+                ctx.HttpContext == httpContext
+                && ctx.Exception == exception
+                && ctx.ProblemDetails.Detail == "Participant not found"));
+    }
+}

--- a/test/UnitTests/WebApi/Validators/OrderDtoValidatorTests.cs
+++ b/test/UnitTests/WebApi/Validators/OrderDtoValidatorTests.cs
@@ -1,6 +1,7 @@
 using FluentValidation.TestHelper;
 
 using MoneyGroup.Core.Models.Orders;
+using MoneyGroup.UnitTests.Builders;
 using MoneyGroup.WebApi.Validators;
 
 namespace MoneyGroup.UnitTests.WebApi.Validators;
@@ -14,15 +15,7 @@ public class OrderDtoValidatorTests
     public async Task GivenOrderDto_WhenValid_ThenHasNoErrors()
     {
         // Arrange
-        var order = new OrderDto()
-        {
-            Title = "Title",
-            BuyerId = 1,
-            Participants =
-            [
-                new ParticipantDto() { ParticipantId = 1 },
-            ],
-        };
+        var order = OrderDtoBuilder.Valid().Build();
 
         // Act
         var result = await _validator.ValidateAsync(order, TestContext.Current.CancellationToken);
@@ -35,10 +28,7 @@ public class OrderDtoValidatorTests
     public async Task GivenOrderDto_WhenTitleEmpty_ThenHasErrorForTitle()
     {
         // Arrange
-        var order = new OrderDto()
-        {
-            Title = "   ",
-        };
+        var order = OrderDtoBuilder.Valid().WithTitle("   ").Build();
 
         // Act
         var result = await _validator.TestValidateAsync(order, cancellationToken: TestContext.Current.CancellationToken);
@@ -51,10 +41,7 @@ public class OrderDtoValidatorTests
     public async Task GivenOrderDto_WhenDescriptionNull_ThenHasNoErrorForDescription()
     {
         // Arrange
-        var order = new OrderDto()
-        {
-            Description = null,
-        };
+        var order = OrderDtoBuilder.Valid().WithDescription(null).Build();
 
         // Act
         var result = await _validator.TestValidateAsync(order, cancellationToken: TestContext.Current.CancellationToken);
@@ -67,10 +54,7 @@ public class OrderDtoValidatorTests
     public async Task GivenOrderDto_WhenBuyerIdZero_ThenHasErrorForBuyerId()
     {
         // Arrange
-        var order = new OrderDto()
-        {
-            BuyerId = 0,
-        };
+        var order = OrderDtoBuilder.Valid().WithBuyer(0).Build();
 
         // Act
         var result = await _validator.TestValidateAsync(order, cancellationToken: TestContext.Current.CancellationToken);
@@ -83,10 +67,7 @@ public class OrderDtoValidatorTests
     public async Task GivenOrderDto_WhenTotalNegative_ThenHasErrorForTotal()
     {
         // Arrange
-        var order = new OrderDto()
-        {
-            Total = -1,
-        };
+        var order = OrderDtoBuilder.Valid().WithTotal(-1).Build();
 
         // Act
         var result = await _validator.TestValidateAsync(order, cancellationToken: TestContext.Current.CancellationToken);
@@ -99,10 +80,7 @@ public class OrderDtoValidatorTests
     public async Task GivenOrderDto_WhenParticipantsNull_ThenHasErrorForParticipants()
     {
         // Arrange
-        var order = new OrderDto()
-        {
-            Participants = null!,
-        };
+        var order = OrderDtoBuilder.Valid().WithNullParticipants().Build();
 
         // Act
         var result = await _validator.TestValidateAsync(order, cancellationToken: TestContext.Current.CancellationToken);
@@ -115,10 +93,7 @@ public class OrderDtoValidatorTests
     public async Task GivenOrderDto_WhenParticipantsEmpty_ThenHasErrorForParticipants()
     {
         // Arrange
-        var order = new OrderDto()
-        {
-            Participants = [],
-        };
+        var order = OrderDtoBuilder.Valid().WithNoParticipants().Build();
 
         // Act
         var result = await _validator.TestValidateAsync(order, cancellationToken: TestContext.Current.CancellationToken);
@@ -131,10 +106,7 @@ public class OrderDtoValidatorTests
     public async Task GivenOrderDto_WhenParticipantsContainsNull_ThenHasErrorForParticipants()
     {
         // Arrange
-        var order = new OrderDto()
-        {
-            Participants = [null!, null!],
-        };
+        var order = OrderDtoBuilder.Valid().WithParticipants([null!, null!]).Build();
 
         // Act
         var result = await _validator.TestValidateAsync(order, cancellationToken: TestContext.Current.CancellationToken);
@@ -147,13 +119,7 @@ public class OrderDtoValidatorTests
     public async Task GivenOrderDto_WhenParticipantsDuplicate_ThenHasDuplicatedParticipantError()
     {
         // Arrange
-        var order = new OrderDto()
-        {
-            Participants = [
-                new ParticipantDto() { ParticipantId = 1 },
-                new ParticipantDto() { ParticipantId = 1 },
-                ],
-        };
+        var order = OrderDtoBuilder.Valid().WithParticipants(1, 1).Build();
 
         // Act
         var result = await _validator.TestValidateAsync(order, cancellationToken: TestContext.Current.CancellationToken);

--- a/test/UnitTests/WebApi/Validators/OrderDtoValidatorTests.cs
+++ b/test/UnitTests/WebApi/Validators/OrderDtoValidatorTests.cs
@@ -3,27 +3,12 @@ using FluentValidation.TestHelper;
 using MoneyGroup.Core.Models.Orders;
 using MoneyGroup.WebApi.Validators;
 
-namespace MoneyGroup.FunctionalTests.Validators;
+namespace MoneyGroup.UnitTests.WebApi.Validators;
 
-public class OrderDtoValidatorTestFixture
+[Trait("Category", "Unit")]
+public class OrderDtoValidatorTests
 {
-    public OrderDtoValidator Validator { get; }
-
-    public OrderDtoValidatorTestFixture()
-    {
-        Validator = new OrderDtoValidator(new ParticipantDtoValidator());
-    }
-}
-
-public class OrderDtoValidatorTest
-    : IClassFixture<OrderDtoValidatorTestFixture>
-{
-    private readonly OrderDtoValidator _validator;
-
-    public OrderDtoValidatorTest(OrderDtoValidatorTestFixture fixture)
-    {
-        _validator = fixture.Validator;
-    }
+    private readonly OrderDtoValidator _validator = new(new ParticipantDtoValidator());
 
     [Fact]
     public async Task GivenOrderDto_WhenValid_ThenReturnNoError()

--- a/test/UnitTests/WebApi/Validators/OrderDtoValidatorTests.cs
+++ b/test/UnitTests/WebApi/Validators/OrderDtoValidatorTests.cs
@@ -11,7 +11,7 @@ public class OrderDtoValidatorTests
     private readonly OrderDtoValidator _validator = new(new ParticipantDtoValidator());
 
     [Fact]
-    public async Task GivenOrderDto_WhenValid_ThenReturnNoError()
+    public async Task GivenOrderDto_WhenValid_ThenHasNoErrors()
     {
         // Arrange
         var order = new OrderDto()
@@ -32,7 +32,7 @@ public class OrderDtoValidatorTests
     }
 
     [Fact]
-    public async Task GivenOrderDto_WhenTitleEmpty_ThenReturnError()
+    public async Task GivenOrderDto_WhenTitleEmpty_ThenHasErrorForTitle()
     {
         // Arrange
         var order = new OrderDto()
@@ -48,7 +48,7 @@ public class OrderDtoValidatorTests
     }
 
     [Fact]
-    public async Task GivenOrderDto_WhenDescriptionNull_ThenReturnNoError()
+    public async Task GivenOrderDto_WhenDescriptionNull_ThenHasNoErrorForDescription()
     {
         // Arrange
         var order = new OrderDto()
@@ -64,7 +64,7 @@ public class OrderDtoValidatorTests
     }
 
     [Fact]
-    public async Task GivenOrderDto_WhenBuyerIdZero_ThenReturnError()
+    public async Task GivenOrderDto_WhenBuyerIdZero_ThenHasErrorForBuyerId()
     {
         // Arrange
         var order = new OrderDto()
@@ -80,7 +80,7 @@ public class OrderDtoValidatorTests
     }
 
     [Fact]
-    public async Task GivenOrderDto_WhenTotalNegative_ThenReturnError()
+    public async Task GivenOrderDto_WhenTotalNegative_ThenHasErrorForTotal()
     {
         // Arrange
         var order = new OrderDto()
@@ -96,7 +96,7 @@ public class OrderDtoValidatorTests
     }
 
     [Fact]
-    public async Task GivenOrderDto_WhenParticipantsNull_ThenReturnError()
+    public async Task GivenOrderDto_WhenParticipantsNull_ThenHasErrorForParticipants()
     {
         // Arrange
         var order = new OrderDto()
@@ -112,7 +112,7 @@ public class OrderDtoValidatorTests
     }
 
     [Fact]
-    public async Task GivenOrderDto_WhenParticipantsEmpty_ThenReturnError()
+    public async Task GivenOrderDto_WhenParticipantsEmpty_ThenHasErrorForParticipants()
     {
         // Arrange
         var order = new OrderDto()
@@ -128,7 +128,7 @@ public class OrderDtoValidatorTests
     }
 
     [Fact]
-    public async Task GivenOrderDto_WhenParticipantsContainsNull_ThenReturnError()
+    public async Task GivenOrderDto_WhenParticipantsContainsNull_ThenHasErrorForParticipants()
     {
         // Arrange
         var order = new OrderDto()
@@ -144,7 +144,7 @@ public class OrderDtoValidatorTests
     }
 
     [Fact]
-    public async Task GivenOrderDto_WhenParticipantsDuplicate_ThenReturnError()
+    public async Task GivenOrderDto_WhenParticipantsDuplicate_ThenHasDuplicatedParticipantError()
     {
         // Arrange
         var order = new OrderDto()

--- a/test/UnitTests/WebApi/Validators/OrderPaginatedRequestValidatorTests.cs
+++ b/test/UnitTests/WebApi/Validators/OrderPaginatedRequestValidatorTests.cs
@@ -3,8 +3,9 @@ using FluentValidation.TestHelper;
 using MoneyGroup.WebApi.Endpoints;
 using MoneyGroup.WebApi.Validators;
 
-namespace MoneyGroup.FunctionalTests.Validators;
+namespace MoneyGroup.UnitTests.WebApi.Validators;
 
+[Trait("Category", "Unit")]
 public class OrderPaginatedRequestValidatorTests
 {
     private readonly OrderPaginatedRequestValidator _validator;

--- a/test/UnitTests/WebApi/Validators/OrderPaginatedRequestValidatorTests.cs
+++ b/test/UnitTests/WebApi/Validators/OrderPaginatedRequestValidatorTests.cs
@@ -16,7 +16,7 @@ public class OrderPaginatedRequestValidatorTests
     }
 
     [Fact]
-    public void Should_Have_Error_When_BuyerId_Is_Less_Than_Or_Equal_To_Zero()
+    public void GivenRequest_WhenBuyerIdNotPositive_ThenHasErrorForBuyerId()
     {
         // Arrange
         var model = new OrderPaginatedRequest(buyerId: 0, participantId: 1, totalMax: 10, totalMin: 1, page: 1, size: 10);
@@ -29,7 +29,7 @@ public class OrderPaginatedRequestValidatorTests
     }
 
     [Fact]
-    public void Should_Have_Error_When_ParticipantId_Is_Less_Than_Or_Equal_To_Zero()
+    public void GivenRequest_WhenParticipantIdNotPositive_ThenHasErrorForParticipantId()
     {
         // Arrange
         var model = new OrderPaginatedRequest(buyerId: 1, participantId: 0, totalMax: 10, totalMin: 1, page: 1, size: 10);
@@ -42,7 +42,7 @@ public class OrderPaginatedRequestValidatorTests
     }
 
     [Fact]
-    public void Should_Have_Error_When_TotalMax_Is_Less_Than_Or_Equal_To_Zero()
+    public void GivenRequest_WhenTotalMaxNotPositive_ThenHasErrorForTotalMax()
     {
         // Arrange
         var model = new OrderPaginatedRequest(buyerId: 1, participantId: 1, totalMax: 0, totalMin: 1, page: 1, size: 10);
@@ -55,7 +55,7 @@ public class OrderPaginatedRequestValidatorTests
     }
 
     [Fact]
-    public void Should_Have_Error_When_TotalMin_Is_Less_Than_Or_Equal_To_Zero()
+    public void GivenRequest_WhenTotalMinNotPositive_ThenHasErrorForTotalMin()
     {
         // Arrange
         var model = new OrderPaginatedRequest(buyerId: 1, participantId: 1, totalMax: 10, totalMin: 0, page: 1, size: 10);
@@ -68,7 +68,7 @@ public class OrderPaginatedRequestValidatorTests
     }
 
     [Fact]
-    public void Should_Have_Error_When_TotalMin_Is_Greater_Than_TotalMax()
+    public void GivenRequest_WhenTotalMinExceedsTotalMax_ThenHasErrorForTotalMin()
     {
         // Arrange
         var model = new OrderPaginatedRequest(buyerId: 1, participantId: 1, totalMax: 5, totalMin: 10, page: 1, size: 10);
@@ -81,7 +81,7 @@ public class OrderPaginatedRequestValidatorTests
     }
 
     [Fact]
-    public void Should_Have_Error_When_Page_Is_Less_Than_One()
+    public void GivenRequest_WhenPageBelowOne_ThenHasErrorForPage()
     {
         // Arrange
         var model = new OrderPaginatedRequest(buyerId: 1, participantId: 1, totalMax: 10, totalMin: 1, page: 0, size: 10);
@@ -94,7 +94,7 @@ public class OrderPaginatedRequestValidatorTests
     }
 
     [Fact]
-    public void Should_Have_Error_When_Size_Is_Less_Than_One()
+    public void GivenRequest_WhenSizeBelowOne_ThenHasErrorForSize()
     {
         // Arrange
         var model = new OrderPaginatedRequest(buyerId: 1, participantId: 1, totalMax: 10, totalMin: 1, page: 1, size: 0);
@@ -108,7 +108,7 @@ public class OrderPaginatedRequestValidatorTests
 
     [Theory]
     [MemberData(nameof(GetEnumerator))]
-    public void Should_Not_Have_Error_When_Valid_Model(int? buyerId, int? participantId, decimal? totalMax, decimal? totalMin, int page, int size)
+    public void GivenRequest_WhenValid_ThenHasNoErrors(int? buyerId, int? participantId, decimal? totalMax, decimal? totalMin, int page, int size)
     {
         // Arrange
         var model = new OrderPaginatedRequest(buyerId, participantId, totalMax, totalMin, page, size);

--- a/test/UnitTests/WebApi/Validators/ParticipantDtoValidatorTests.cs
+++ b/test/UnitTests/WebApi/Validators/ParticipantDtoValidatorTests.cs
@@ -3,17 +3,12 @@ using FluentValidation.TestHelper;
 using MoneyGroup.Core.Models.Orders;
 using MoneyGroup.WebApi.Validators;
 
-namespace MoneyGroup.FunctionalTests.Validators;
+namespace MoneyGroup.UnitTests.WebApi.Validators;
 
-public class ParticipantDtoValidatorTest
-    : IClassFixture<ParticipantDtoValidator>
+[Trait("Category", "Unit")]
+public class ParticipantDtoValidatorTests
 {
-    private readonly ParticipantDtoValidator _validator;
-
-    public ParticipantDtoValidatorTest(ParticipantDtoValidator validator)
-    {
-        _validator = validator;
-    }
+    private readonly ParticipantDtoValidator _validator = new();
 
     [Fact]
     public async Task GivenOrderDto_WhenParticipantIdZero_ThenReturnError()

--- a/test/UnitTests/WebApi/Validators/ParticipantDtoValidatorTests.cs
+++ b/test/UnitTests/WebApi/Validators/ParticipantDtoValidatorTests.cs
@@ -11,7 +11,7 @@ public class ParticipantDtoValidatorTests
     private readonly ParticipantDtoValidator _validator = new();
 
     [Fact]
-    public async Task GivenOrderDto_WhenParticipantIdZero_ThenReturnError()
+    public async Task GivenParticipant_WhenParticipantIdZero_ThenHasErrorForParticipantId()
     {
         // Arrange
         var participant = new ParticipantDto()

--- a/test/UnitTests/packages.lock.json
+++ b/test/UnitTests/packages.lock.json
@@ -51,20 +51,399 @@
         "resolved": "6.0.0",
         "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
       },
+      "Microsoft.Bcl.Cryptography": {
+        "type": "Transitive",
+        "resolved": "9.0.13",
+        "contentHash": "5T+bH3Lb1nEe8Hf/ixMxLmhlrx5wRi53wv7OhVwG2F1ZviW1ejFRS1NHur3uqPpJRGtkQwUchtY6zhVK2R+v+w=="
+      },
+      "Microsoft.Data.SqlClient": {
+        "type": "Transitive",
+        "resolved": "7.0.1",
+        "contentHash": "9jZFXAJ2ThNYK7lhj2RhH7klXVNaWSvZpQncq3bPIOjmHBrdjwgeO4c8wucUVxQwFT8rAA13Z2F2jzoYR7ICDw==",
+        "dependencies": {
+          "Microsoft.Bcl.Cryptography": "9.0.13",
+          "Microsoft.Data.SqlClient.Extensions.Abstractions": "1.0.0",
+          "Microsoft.Data.SqlClient.Internal.Logging": "1.0.0",
+          "Microsoft.Data.SqlClient.SNI.runtime": "6.0.2",
+          "Microsoft.Extensions.Caching.Memory": "9.0.13",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.16.0",
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "8.16.0",
+          "Microsoft.SqlServer.Server": "1.0.0",
+          "System.Configuration.ConfigurationManager": "9.0.13",
+          "System.Security.Cryptography.Pkcs": "9.0.13"
+        }
+      },
+      "Microsoft.Data.SqlClient.Extensions.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "rlnxc0KfwDSbE8ZHntFnl8SCgOa9QtJZblMv2zXLhRwl1Je7fsdsVzxSjzzC4JMsfAK+jXJWyezRB8SxUY4BdA==",
+        "dependencies": {
+          "Microsoft.Data.SqlClient.Internal.Logging": "1.0.0"
+        }
+      },
+      "Microsoft.Data.SqlClient.Internal.Logging": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "Kue/7CF8KNT9zozfr30C94dMZVZml3atqWZvQemSXvTau76tRdypzeKiBKXadqgbOME0UiQIyVTNo5WxCRNVNg=="
+      },
+      "Microsoft.Data.SqlClient.SNI.runtime": {
+        "type": "Transitive",
+        "resolved": "6.0.2",
+        "contentHash": "f+pRODTWX7Y67jXO3T5S2dIPZ9qMJNySjlZT/TKmWVNWe19N8jcWmHaqHnnchaq3gxEKv1SWVY5EFzOD06l41w=="
+      },
       "Microsoft.DiaSymReader": {
         "type": "Transitive",
         "resolved": "2.2.3",
         "contentHash": "bhwzJfzyiJM0nXJyNB7Y9OfsEXyxLdDBHG99soIp5JjnPydwkOaBdRCtRtWgQh3noSLi2cSIZ/wpbHNNE9knxQ=="
+      },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "GRMaiPkqYna/gCsyDffYDWmefGPC3hDrdMw+2rrGcQwhs6uZOsaMQXMJnoXQ35tx9SkBV2ieRRU9N/jLOO6BZw=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "aiEFB+C5EsZGqxvMPazE07hbWsp4iPaufJpanGt5O+lrwv7mJLrqma5haVIgFAPCyhQkmk75XSCEubT1zUjxtA=="
+      },
+      "Microsoft.Extensions.AmbientMetadata.Application": {
+        "type": "Transitive",
+        "resolved": "10.7.0",
+        "contentHash": "yZ0818pVYQvUFW/1m+f8A1+lIAeSeQxEOdUCMIC+tqcRRKlqNjKPRKvGHPp8xLRbZBLaHfBtDslJa/sofn7J/Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "5fGxcw2vuYp8s0wio9H1ECiuk4iKSdTIlNuigdLIrkhg+5XAwgFVDB/5Ots3pfN/QhABLYXutA79JFtnUKDSHA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "G9mregdatGWMCQWeCw012LDeJVP7G/XIxH8Ddbjc8bD1//dA+8VVQdcRE9jI1moyoJxSSZhHITUnNQ8FUDl5+Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Compliance.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.7.0",
+        "contentHash": "qbi6lg6dyvydBvpjXeBx3wLPvmgXWn3nwkKBOsgEck6w++BEsBcv8YhdcczME16Oq+a6wkdtna9/qCEkxsNw5A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.ObjectPool": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "woZsWLhOQsASuxbmgiZJqiGUBNo3IjRdXC92xt8rRokza+P6/nIsnzq7sm9Or6ZYcRl2kL1ufj8HVzp1QlPTXw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "qGhRPd3VxfLV9UqatVOiD9mAeUbj2KiMwGFYC5uXlzExiZQoe4X/hdmzGIU7BQjNLTqCnnbTHVyBglG3668/HA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "Tp/+LPb70RyjjtLg9m5C959eP4KrUpJHThZfAegZVpsfmGvzfuNkuYbI/ft+LvXhMSyUcAeOPaN6rzTccwnZAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "NijozhERJDIaJ4k5TSMy1jOi0cSC2HfkvRD/Sl+kGSSKgVbFnF4GxgtMN/MrzHB8D1JxIrD4xSer9Blh9v3axQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
+        }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.9",
         "contentHash": "g41l/30G3K4B/d/L8kjux0+30e27c8D0FVQ/PFCpbekgfDpj9mnDhieP67EqXWvl1EWNeZh2rpR4F5B/jcDOHA=="
       },
+      "Microsoft.Extensions.DependencyInjection.AutoActivation": {
+        "type": "Transitive",
+        "resolved": "10.7.0",
+        "contentHash": "WrSK0FGHSjSY4Pg4kd9Du8CUDwrgFTwHH1Y+N7sjyT6RFMU+G3coQ/Uq9PMGdQcy+DVKSMGHjfmWY47ZoYvhNA==",
+        "dependencies": {
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.9"
+        }
+      },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
         "resolved": "8.0.2",
         "contentHash": "mUBDZZRgZrSyFOsJ2qJJ9fXfqd/kXJwf3AiDoqLD9m6TjY5OO/vLNOb9fb4juC0487eq4hcGN/M2Rh/CKS7QYw=="
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "NLXI3PbTe39q6/sgs7JYhmfPf7bMzReUoAJ0q9Po6yhfM+0anZa7PrEva4W2SdiLWGyB9eKZS9THGt2BP40xJg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "86RgyFsmVslW4Nu28IXgt8tLglynGQrwjk/xhGZaTe8j6YIeR1Ywoc42hSHsBSl920CQdfqq2dBohZiGm3AkUA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.ExceptionSummarization": {
+        "type": "Transitive",
+        "resolved": "10.7.0",
+        "contentHash": "Kc4XbbxtCzvn2P/fKF48xLWPbp3N5DV0MkJlgPJHEb47PUqCJ6kEl/JTKfpmP7QLuwYjx2QxKTdtwXfpjgA6KQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "I3mmGlsR73z+7SJJ1ngUG6JfH+UEVTm/42leXxzzr6OKC9DqYIqwZKAjumoH3HEcRqfGPOpo/lfECifQN7qgUA==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "/pbRl7IJW3QFzEwBGtgEvcEUbL9OGFe+1uTMisWLIS+NaHH5+PEQ3/Sw58c4UqXKlC/rtqFp+qSOGelEelNAjA=="
+      },
+      "Microsoft.Extensions.Features": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "ohU5761fyZq7eSg0nLQMzHvCrGGGmyzgRzAGebHZlQ4D7/9v9uzPYJ/AUYcD5kNSiOWR34Ma4qGgKs0PUPrYZw=="
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "Oxn4vqDk+EwceTMpZxVm7L/UZEAM1qIQlNP1+7tBZckD+P4SKrm/5X4gMTPCTdpnau/xY8Sb4/0d6onomSg4ZA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "Xd/2F+uWblTiUp+ssaDZN2ea4vmnHmW6PXugmqBHumyhqVkyeh6RJ3S2Zo/F+1bXIL/KuGqe2pKv6UiGOc1KeQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.9",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Http": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "5jdmuLRg1HO7x/v8McOf6ndhkMQWImkRBtJpXM8+xIocXNdLqCItyyFLKusdILc62TDzHuLlqaWoxtOA5FFOPg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Diagnostics": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Http.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.7.0",
+        "contentHash": "1m1zdBGW5J8MOxdZpJ5mUqdSaamRrYkpmfnEfeDmlZnglpfgDztcKOBU6cVsmn90AB7Ji2w8USvEsJ8PahbBWQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Http": "10.0.9",
+          "Microsoft.Extensions.Telemetry": "10.7.0"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "N7Gm9SjugYjmmnhwbBKC9DFqGqjfJvh6YfOJgtwh0AW0Xpok3dIVors1ik050XmUxKAgAc7nNngDIJyFb06K2g==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "bUth5ip7YsZMXWZS42IRTI0zDrPEqdE+xnsmcL0Pk784grWKApDvc5UoMi2tP2qYJ5ylFzeVDuDu08sFATq1bg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "KZENCkfqO7Ciax6goUWQHDSxKH+x763hkBWMz9KpE87EyKW+EKEas9EFe9i1KgtQShG8KwKxaeJ5gd9sj6TuTQ=="
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "hyNdX4c2UwkRkzb9byw0H2DQkRzwBM3mzY2sCM9egwzTyg8dvQJmp5noQHGEaaCORQrNK3DD2gREBsc2DlXS4A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "Y4E24zffF/aPS0igNvY6ZzAQfbxd6AYdC9L4brnH+uK0yYYHIR6FeGVQVVjAOo8wub1EQDl2B90lCcpqoTF7Yw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.9",
+        "contentHash": "fmEbAUFsaIKirgLt/lYhuFRBwhcSJN31jjHgCdbQxJiWOum6EdLjkbgGuukSP9z/a+9LibaxII/kF+GwOXgC4g=="
+      },
+      "Microsoft.Extensions.Resilience": {
+        "type": "Transitive",
+        "resolved": "10.7.0",
+        "contentHash": "ldUrtRzWSnfe5945xoSxDXxoWXnIKn19E74Huieyp76XW/BjRk3bhkILSSib1NKdZ2lpi/ReTvOpNGcJ8hkOxw==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics": "10.0.9",
+          "Microsoft.Extensions.Diagnostics.ExceptionSummarization": "10.7.0",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.9",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.7.0",
+          "Polly.Extensions": "8.4.2",
+          "Polly.RateLimiting": "8.4.2"
+        }
+      },
+      "Microsoft.Extensions.ServiceDiscovery.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.7.0",
+        "contentHash": "1a/tCYg7+5HdJRQ0BQDDGzANBaw/1fony7eNsMwQ5n9FZmO3K5JCls02o8fwQc296l0szNBwroLRtXf94OZw9A==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.9",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Features": "10.0.9",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9",
+          "Microsoft.Extensions.Primitives": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "10.7.0",
+        "contentHash": "vZFNVvkz+7IABEv4klzPX/ZdmZQ6TrcReKUfeYIrQ2bbnvEcgZtG1RmOGeWkc1hFg8cq9sAgUc2lHCqlXSqf5A==",
+        "dependencies": {
+          "Microsoft.Extensions.AmbientMetadata.Application": "10.7.0",
+          "Microsoft.Extensions.DependencyInjection.AutoActivation": "10.7.0",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.9",
+          "Microsoft.Extensions.ObjectPool": "10.0.9",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.7.0"
+        }
+      },
+      "Microsoft.Extensions.Telemetry.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.7.0",
+        "contentHash": "ir1QKShZzfEmqO9LUWESVMUDZdnxYBSKQyulYPMeaye531lAuT8YTotthx+htrrS8hZY52HANeqowLQyCYBCZg==",
+        "dependencies": {
+          "Microsoft.Extensions.Compliance.Abstractions": "10.7.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.ObjectPool": "10.0.9",
+          "Microsoft.Extensions.Options": "10.0.9"
+        }
+      },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "gSxKLWRZzBpIsEoeUPkxfywNCCvRvl7hkq146XHPk5vOQc9izSf1I+uL1vh4y2U19QPxd9Z8K/8AdWyxYz2lSg=="
+      },
+      "Microsoft.IdentityModel.JsonWebTokens": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "prBU72cIP4V8E9fhN+o/YdskTsLeIcnKPbhZf0X6mD7fdxoZqnS/NdEkSr+9Zp+2q7OZBOMfNBKGbTbhXODO4w==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.16.0"
+        }
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "MTzXmETkNQPACR7/XCXM1OGM6oU9RkyibqeJRtO9Ndew2LnGjMf9Atqj2VSf4XC27X0FQycUAlzxxEgQMWn2xQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "8.16.0"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "UFrU7d46UTsPQTa2HIEIpB9H1uJe1BW9FLw5uhEJ2ZuKdur8bcUA/bO5caq5dlBt5gNJeRIB3QQXYNs5fCQCZA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.16.0"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols.OpenIdConnect": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "h4yVXyJsEBBX5lg2G5ftMsi5JzcNEGAzrNphA6DQ6eOd8P0s+cDCOyPwVTYLePZvJL5unbPvYIvzrbTXzFjXnQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols": "8.16.0",
+          "System.IdentityModel.Tokens.Jwt": "8.16.0"
+        }
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "rtViGJcGsN7WcfUNErwNeQgjuU5cJNl6FDQsfi9TncwO+Epzn0FTfBsg3YuFW1Q0Ch/KPxaVdjLw3/+5Z5ceFQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.IdentityModel.Logging": "8.16.0"
+        }
+      },
+      "Microsoft.SqlServer.Server": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "N4KeF3cpcm1PUHym1RmakkzfkEv3GRMyofVv40uXsQhCQeglr2OHNcUk2WOG51AKpGO8ynGpo9M/kFXSzghwug=="
       },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
@@ -101,10 +480,109 @@
         "resolved": "5.0.0",
         "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
       },
+      "OpenTelemetry": {
+        "type": "Transitive",
+        "resolved": "1.16.0",
+        "contentHash": "nE/Px3MUvQC8c0UG0DOP5OJE7vMtiMaPYi/6TkSS/o/O0s/oPq+8WaPYTVEPzb7lwu/QyLgknc+sFm2FjPXe2A==",
+        "dependencies": {
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.0",
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "1.16.0"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "Transitive",
+        "resolved": "1.16.0",
+        "contentHash": "WZP8Eb6vZTeNqeV+fjBitc7iefBoTHIhaWorqg/h/YiQBlcQJu0bICuTqKV0XRyjiE0eWs80yLlnUtHAFSkFWA=="
+      },
+      "OpenTelemetry.Api.ProviderBuilderExtensions": {
+        "type": "Transitive",
+        "resolved": "1.16.0",
+        "contentHash": "hZwaHAkXvUNn9+cS+vEvYBgIrIQOQRz2cIRUODZ5gxHsDsLeNCueLgZFkybopjE0jUhLut6lm5eL3LTqbW0hMg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "OpenTelemetry.Api": "1.16.0"
+        }
+      },
+      "OpenTelemetry.Instrumentation.SqlClient": {
+        "type": "Transitive",
+        "resolved": "1.15.2",
+        "contentHash": "pRB84YJEXD121kygc6CtcF46dtLuTKIjphA2SJye32G4g2Xl3epkCrOcPCOAg4WDagCdMGa16Ge6PPVzFJZsAQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
+        }
+      },
+      "Polly.Core": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "BpE2I6HBYYA5tF0Vn4eoQOGYTYIK1BlF5EXVgkWGn3mqUUjbXAr13J6fZVbp7Q3epRR8yshacBMlsHMhpOiV3g=="
+      },
+      "Polly.Extensions": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "GZ9vRVmR0jV2JtZavt+pGUsQ1O1cuRKG7R7VOZI6ZDy9y6RNPvRvXK1tuS4ffUrv8L0FTea59oEuQzgS0R7zSA==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
+          "Microsoft.Extensions.Options": "8.0.0",
+          "Polly.Core": "8.4.2"
+        }
+      },
+      "Polly.RateLimiting": {
+        "type": "Transitive",
+        "resolved": "8.4.2",
+        "contentHash": "ehTImQ/eUyO07VYW2WvwSmU9rRH200SKJ/3jku9rOkyWE0A2JxNFmAVms8dSn49QLSjmjFRRSgfNyOgr/2PSmA==",
+        "dependencies": {
+          "Polly.Core": "8.4.2",
+          "System.Threading.RateLimiting": "8.0.0"
+        }
+      },
+      "SharpGrip.FluentValidation.AutoValidation.Shared": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "0DWoin27wm38K/O0zVS5yeWJld2eg588B+4wJSmVlISrOj3kGwRmWCEXFR8lTNWFnKpXHNOtrIo1vdZnhkhzQg==",
+        "dependencies": {
+          "FluentValidation": "10.0.0"
+        }
+      },
+      "System.Configuration.ConfigurationManager": {
+        "type": "Transitive",
+        "resolved": "9.0.13",
+        "contentHash": "GbBrJq9S/gYpHzm7Pxx6Y5tDyfSfyxW6tlP5oiKJV38uf19Wp+GIIAnWfyL1zmNiz1+EjwVapw2WkBFvvqKQzg==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "9.0.13",
+          "System.Security.Cryptography.ProtectedData": "9.0.13"
+        }
+      },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
+        "resolved": "9.0.13",
+        "contentHash": "675Rk4RwaVrWo09wrR2rpDVKixtgtnhd5NhPrn6O21uj92JvE61KTGupn76M2N6Ff/xJjY3SHSfSg0MIanEzGw=="
+      },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "rrs2u7DRMXQG2yh0oVyF/vLwosfRv20Ld2iEpYcKwQWXHjfV+gFXNQsQ9p008kR9Ou4pxBs68Q6/9zC8Gi1wjg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "8.16.0",
+          "Microsoft.IdentityModel.Tokens": "8.16.0"
+        }
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "2wOycCqMyg9Tu+SDP03FFwDEWBni/3xOKgt0bRXplOvyeIcUJmWO7m3gTCF2mIdtQLROLtOP5VwWRT8YBwP/bA=="
+      },
+      "System.Security.Cryptography.ProtectedData": {
+        "type": "Transitive",
+        "resolved": "9.0.13",
+        "contentHash": "t8S9IDpjJKsLpLkeBdW8cWtcPyYqrGu93Dej1RO6WwuL/lkFSqWlan3rMJfortqz1mRIh+sys2AFsSA6jWJ3Jg=="
+      },
+      "System.Threading.RateLimiting": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "7mu9v0QDv66ar3DpGSZHg9NuNcxDaaAcnMULuZlaTpP9+hwXhrxNGsF5GmLkSHxFdb5bBc1TzeujsRgTrPWi+Q=="
       },
       "xunit.analyzers": {
         "type": "Transitive",
@@ -170,11 +648,174 @@
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.9, )"
         }
       },
+      "moneygroup.infrastructure": {
+        "type": "Project",
+        "dependencies": {
+          "Ardalis.Specification.EntityFrameworkCore": "[9.3.1, )",
+          "Microsoft.EntityFrameworkCore": "[10.0.9, )",
+          "MoneyGroup.Core": "[1.0.0, )"
+        }
+      },
+      "moneygroup.infrastructure.sqlserver": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.SqlServer": "[10.0.9, )",
+          "MoneyGroup.Infrastructure": "[1.0.0, )"
+        }
+      },
+      "moneygroup.servicedefaults": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Resilience": "[10.7.0, )",
+          "Microsoft.Extensions.ServiceDiscovery": "[10.7.0, )",
+          "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.16.0, )",
+          "OpenTelemetry.Extensions.Hosting": "[1.16.0, )",
+          "OpenTelemetry.Instrumentation.AspNetCore": "[1.16.0, )",
+          "OpenTelemetry.Instrumentation.GrpcNetClient": "[1.16.0-beta.1, )",
+          "OpenTelemetry.Instrumentation.Http": "[1.16.0, )",
+          "OpenTelemetry.Instrumentation.Runtime": "[1.15.1, )"
+        }
+      },
+      "moneygroup.webapi": {
+        "type": "Project",
+        "dependencies": {
+          "Aspire.Microsoft.EntityFrameworkCore.SqlServer": "[13.4.6, )",
+          "FluentValidation": "[12.1.1, )",
+          "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.9, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.0.9, )",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[10.0.9, )",
+          "Microsoft.VisualStudio.Azure.Containers.Tools.Targets": "[1.23.0, )",
+          "MoneyGroup.Core": "[1.0.0, )",
+          "MoneyGroup.Infrastructure": "[1.0.0, )",
+          "MoneyGroup.Infrastructure.SqlServer": "[1.0.0, )",
+          "MoneyGroup.ServiceDefaults": "[1.0.0, )",
+          "SharpGrip.FluentValidation.AutoValidation.Endpoints": "[2.0.0, )",
+          "Swashbuckle.AspNetCore.SwaggerUI": "[10.2.3, )"
+        }
+      },
       "Ardalis.Specification": {
         "type": "CentralTransitive",
         "requested": "[9.3.1, )",
         "resolved": "9.3.1",
         "contentHash": "GWrE6BA0smWFLbN+XPU2l5rDF9Uzelfbb3w35jJ0CGIat+p1ChbtLcbkvYRMEculBHOAo12omwAAOm3VFWkoJQ=="
+      },
+      "Ardalis.Specification.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[9.3.1, )",
+        "resolved": "9.3.1",
+        "contentHash": "QbOo4E6HWdKXZ9QUrqcgiGN4EKtzt0kzGzqr2zc32q5QESzBrceJ3GX1ymWVdCCOzJO1+GPm+/a/5ovSkfrLoQ==",
+        "dependencies": {
+          "Ardalis.Specification": "9.3.1",
+          "Microsoft.EntityFrameworkCore": "9.0.8",
+          "Microsoft.EntityFrameworkCore.Relational": "9.0.8"
+        }
+      },
+      "Aspire.Microsoft.EntityFrameworkCore.SqlServer": {
+        "type": "CentralTransitive",
+        "requested": "[13.4.6, )",
+        "resolved": "13.4.6",
+        "contentHash": "jby3aZVvf8y1WbAa/nGpj5+bOsIbazFylYIiVZVmeeKsycOXN/8AwYfvr4+C8jsVnh1UsbcBUuEEb5p5EqMD0g==",
+        "dependencies": {
+          "Microsoft.Data.SqlClient": "7.0.1",
+          "Microsoft.EntityFrameworkCore.SqlServer": "10.0.8",
+          "Microsoft.Extensions.Caching.Memory": "10.0.8",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.8",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.8",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "10.0.8",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Logging": "10.0.8",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.8",
+          "Microsoft.Extensions.Options": "10.0.8",
+          "Microsoft.Extensions.Primitives": "10.0.8",
+          "OpenTelemetry.Extensions.Hosting": "1.15.3",
+          "OpenTelemetry.Instrumentation.SqlClient": "1.15.2",
+          "System.Security.Cryptography.Pkcs": "10.0.8"
+        }
+      },
+      "FluentValidation": {
+        "type": "CentralTransitive",
+        "requested": "[12.1.1, )",
+        "resolved": "12.1.1",
+        "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
+      },
+      "Microsoft.AspNetCore.Authentication.JwtBearer": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "Hs5NDsGm8YicDDNx5RoBIT+H2AB9R27MvZ2gHoupTiHr+nnH3VxzY7DcmlbJ3b5DvvOhK35lWt/9Odtrq9sjtA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "8.0.1"
+        }
+      },
+      "Microsoft.AspNetCore.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "1ihb8FO9cGgEK1/m3CTtT/SfnynwmiZib0W2pcDVj3KSWk/Sca4VOXEtaptKQc582zpFrzTFiwkGRCglt6H+WQ==",
+        "dependencies": {
+          "Microsoft.OpenApi": "2.0.0"
+        }
+      },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "tu85SRzOT021V7EQlViCiAE7TqldVn469Y6lt5TEn/+XC4/MeNCHgMRSxqYuWqvF4zAQZUhCmtNEZuM3ss4LeA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.9",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.9",
+          "Microsoft.Extensions.Caching.Memory": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "dEoyYKgiaZHHgOFm1WMWm1sFEsEuhPWufX4L9PekKtqd/RaIcPjkCjvbrVvJtApErb5wPSJhYvnTlxhH+p9h2g==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.9",
+          "Microsoft.Extensions.Caching.Memory": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.SqlServer": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "wjgpB/UFSeMU3uMfMzD4so567vJi5UugE6iTcONBx+rPb/PWpjYlzYKyxm2pGAFNpTFNbqoirtt7uUCc97Tfiw==",
+        "dependencies": {
+          "Microsoft.Data.SqlClient": "6.1.1",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.9",
+          "Microsoft.Extensions.Caching.Memory": "10.0.9",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.9",
+          "Microsoft.Extensions.Logging": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.9, )",
+        "resolved": "10.0.9",
+        "contentHash": "QPT82DUkDXsgqXGKnyYcm0SJ1b3ryv1FRrsLcfmueAYIt2GmYqNmRLd7giFbHbB19uXSrExUeOa9r1RncATIGw==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.9",
+          "Microsoft.Extensions.Diagnostics.HealthChecks": "10.0.9",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.9"
+        }
+      },
+      "Microsoft.Extensions.Http.Resilience": {
+        "type": "CentralTransitive",
+        "requested": "[10.7.0, )",
+        "resolved": "10.7.0",
+        "contentHash": "3Lip0MkBVPtqU1wCM2M2Y8CzsqxA1BanVNMV9LQYMTwBgy25NDe6U9nSk6SfmsxXlh77iwSQuPsyjt5mxrOGmQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Http.Diagnostics": "10.7.0",
+          "Microsoft.Extensions.ObjectPool": "10.0.9",
+          "Microsoft.Extensions.Resilience": "10.7.0"
+        }
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
@@ -184,6 +825,100 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
         }
+      },
+      "Microsoft.Extensions.ServiceDiscovery": {
+        "type": "CentralTransitive",
+        "requested": "[10.7.0, )",
+        "resolved": "10.7.0",
+        "contentHash": "UgBfP98NmKDjx/2jbLGkckSlc8XG4ubkjPrqACE2i9LPmrgoYGWTh9snybRUGBm0sTchsq3on81XRxfvX+XC5g==",
+        "dependencies": {
+          "Microsoft.Extensions.Http": "10.0.9",
+          "Microsoft.Extensions.ServiceDiscovery.Abstractions": "10.7.0"
+        }
+      },
+      "Microsoft.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[2.7.5, )",
+        "resolved": "2.7.5",
+        "contentHash": "0FA67RSnRM4tcBKqiqVu/HPdZ9+QOKbmeRjxRUGTCjPU4C0bmUhd97Dso7Yild5P7nOV6GxJ2xrK0Kv/O9xp0w=="
+      },
+      "Microsoft.VisualStudio.Azure.Containers.Tools.Targets": {
+        "type": "CentralTransitive",
+        "requested": "[1.23.0, )",
+        "resolved": "1.23.0",
+        "contentHash": "2wDnb4umupJZ/1ikgWozFVpggH1mlHQFc0odXVv2ZagL3RYwXgW9zmC15fiqIBzmaC0vLZUnLGwDY+p8ZR7Syw=="
+      },
+      "OpenTelemetry.Exporter.OpenTelemetryProtocol": {
+        "type": "CentralTransitive",
+        "requested": "[1.16.0, )",
+        "resolved": "1.16.0",
+        "contentHash": "gzYLY8sVDY5FYtVlCYSzBYX53xslRlvBLxwFYOdNIhc76SgKdFYUoDQXOeQI3WPBCrZp51QNcP6fZHh1+HtpIQ==",
+        "dependencies": {
+          "OpenTelemetry": "1.16.0"
+        }
+      },
+      "OpenTelemetry.Extensions.Hosting": {
+        "type": "CentralTransitive",
+        "requested": "[1.16.0, )",
+        "resolved": "1.16.0",
+        "contentHash": "/YfrO5MRaA156vhNanYGPX2JjOwKUrA0+Jf7ltT2eD3VkfHqXcEJY5Oxt/nWH8lqBOTc1nJpn2soBtD5Cml8Dg==",
+        "dependencies": {
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "OpenTelemetry": "1.16.0"
+        }
+      },
+      "OpenTelemetry.Instrumentation.AspNetCore": {
+        "type": "CentralTransitive",
+        "requested": "[1.16.0, )",
+        "resolved": "1.16.0",
+        "contentHash": "vSC5EsmBVNcqXMh9BGkkq8zkoUjrg8ghBDb9zbKR8Bqjd05utjVgVft+fqsqQVsvlV5olGj1pBliHBngcIGSIg==",
+        "dependencies": {
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.16.0, 2.0.0)"
+        }
+      },
+      "OpenTelemetry.Instrumentation.GrpcNetClient": {
+        "type": "CentralTransitive",
+        "requested": "[1.16.0-beta.1, )",
+        "resolved": "1.16.0-beta.1",
+        "contentHash": "gwyEXRWLXNRyZrbOXrZfFIsMExvztDXUT1qy3JUp21xldo5LzwM0tnKrTxswHP4yFr6FOVryZa2UWPDvjQaF1Q==",
+        "dependencies": {
+          "OpenTelemetry": "[1.16.0, 2.0.0)"
+        }
+      },
+      "OpenTelemetry.Instrumentation.Http": {
+        "type": "CentralTransitive",
+        "requested": "[1.16.0, )",
+        "resolved": "1.16.0",
+        "contentHash": "+Sz3lfvMXwWE8s/sMruHCDlO/+cArFVc6oBg1tCb70BKlL9FCC7uK4Ar2/VP9Hhwvs+UwaW1vGzE/uiByVHXiA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.16.0, 2.0.0)"
+        }
+      },
+      "OpenTelemetry.Instrumentation.Runtime": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.1, )",
+        "resolved": "1.15.1",
+        "contentHash": "cpPwlUT5HXcLGPaIgsbSy0W9eFYAPGVbTP1p8/uyQ4Osvf5BJuPpEXE7crL09SmEd44r0DGNKDtsqxaAz0HxQw==",
+        "dependencies": {
+          "OpenTelemetry.Api": "[1.15.3, 2.0.0)"
+        }
+      },
+      "SharpGrip.FluentValidation.AutoValidation.Endpoints": {
+        "type": "CentralTransitive",
+        "requested": "[2.0.0, )",
+        "resolved": "2.0.0",
+        "contentHash": "XO7t6wVt1XmO2BG2Y23X8/CFnu0r7XVlJTcWymTNoyXHHcr0Kip+b3IEe+Gc7kNqTXnCO+Rrmt6Xy9YdJ3b6yw==",
+        "dependencies": {
+          "SharpGrip.FluentValidation.AutoValidation.Shared": "2.0.0"
+        }
+      },
+      "Swashbuckle.AspNetCore.SwaggerUI": {
+        "type": "CentralTransitive",
+        "requested": "[10.2.3, )",
+        "resolved": "10.2.3",
+        "contentHash": "nthWONRs/FJ4yyG206g1cC52WEG8EqrjuMWjGdR+5XG7lbjFto6NqcI9EMICgVFom/UivIjUVwI76ZHbHwTPfQ=="
       }
     }
   }

--- a/test/UnitTests/packages.lock.json
+++ b/test/UnitTests/packages.lock.json
@@ -22,6 +22,15 @@
           "Castle.Core": "5.1.1"
         }
       },
+      "NSubstitute": {
+        "type": "Direct",
+        "requested": "[6.2.0, )",
+        "resolved": "6.2.0",
+        "contentHash": "05oaAmBAvYYUQb/NTb9/kWBDjq0iS772X4t428WJcHRcH+5ULJx6rTbEvqkZJBIHWRLI8MlU3et3F5/gkEHKIw==",
+        "dependencies": {
+          "Castle.Core": "5.1.1"
+        }
+      },
       "xunit.v3.mtp-v2": {
         "type": "Direct",
         "requested": "[3.2.2, )",

--- a/test/UnitTests/packages.lock.json
+++ b/test/UnitTests/packages.lock.json
@@ -13,15 +13,6 @@
           "Microsoft.Testing.Platform": "2.2.3"
         }
       },
-      "Moq": {
-        "type": "Direct",
-        "requested": "[4.20.72, )",
-        "resolved": "4.20.72",
-        "contentHash": "EA55cjyNn8eTNWrgrdZJH5QLFp2L43oxl1tlkoYUKIE9pRwL784OWiTXeCV5ApS+AMYEAlt7Fo03A2XfouvHmQ==",
-        "dependencies": {
-          "Castle.Core": "5.1.1"
-        }
-      },
       "NSubstitute": {
         "type": "Direct",
         "requested": "[6.2.0, )",


### PR DESCRIPTION
Slice 1 of 4 from `docs/superpowers/specs/2026-08-15-unit-test-foundation-design.md` (design + plan in this PR's first three commits). Brainstormed and scoped with the user before any code moved.

## Problem

Of 48 tests in `MoneyGroup.FunctionalTests`, 28 never started a host, never issued an HTTP request, and never touched a database — they were unit tests living in the wrong project. That made it impossible to run "just the fast tests" and made a reader guess which pyramid level a file belonged to. Separately, three different mocking idioms and two naming conventions coexisted with no single idiom locked in before the bulk of the suite gets written.

## What changed

**Phase 1 — relocation (63 → 63 tests, pure motion):**
- Moved 4 validator/authorization test files and 1 service test file from `FunctionalTests`/misplaced `UnitTests` folders into `UnitTests`, mirroring `src/` layout under `Core/`, `WebApi/`.
- Deleted `OrderDtoValidatorTestFixture` (cached a stateless, allocation-free validator) and stopped `ParticipantDtoValidatorTest` using a **production type** (`ParticipantDtoValidator`) as an `IClassFixture`.
- Dropped the `Moq` package reference from `FunctionalTests` — nothing there mocks any more.

**Phase 2 — lock the idiom (still 63 tests):**
- Added NSubstitute 6.2.0, converted every Moq usage to it. Every `Verify` became an explicit `Received`/`DidNotReceive` — NSubstitute has no throw-on-missing-verification equivalent, so a forgotten assertion passes silently if skipped. Converted one file per commit with a green run between.
- Replaced `Mock<ClaimsPrincipal>` with a real `ClaimsPrincipal`, removing a coupling to `FindFirstValue`'s internal use of `FindFirst`.
- Renamed all unit test methods to `Given_When_Then`. Two old names were actively wrong (asserted `false`/no-throw while named `...ShouldThrow...`).
- Introduced `OrderDtoBuilder`/`UserDtoBuilder` (hand-written, not AutoFixture — explicit and reproducible). Collapsed duplicated inline DTO literals onto them.
- Retired a `#pragma warning disable CA1859` by typing a test field as the concrete `OrderService` instead of the interface.

**Phase 3 — close the unit-testable gaps (63 → 106 tests):**
- `UserService` (all 3 methods, including `GetUserByEmailAsync` which functional tests never reach because they bypass authorization).
- All 6 `Ardalis.Specification` specifications, including `OrderPaginatedSpec`'s filter combinations and ordering — previously exercised only indirectly through repository integration tests.
- The Mapperly-generated `Mapper` — contributes no coverage (generated code is `[GeneratedCode]`-excluded already) but is the highest-value addition: a source-generated mapper silently dropping a property is exactly what a functional test's `Assert.NotNull` cannot catch.
- `BusinessValidationExceptionHandler`, `OrderService.GetOrdersByPageAsync` (the one method with no prior test).
- **Only production change in this PR:** all 7 minimal-API endpoint handlers in `OrderEndpoints`/`UserEndpoints` normalized to `internal static` (fixes an existing inconsistency where 2 of 7 were `public` while the rest were `private`), plus `<InternalsVisibleTo Include="MoneyGroup.UnitTests" />` — extending a pattern already used twice in this repo. Handlers return typed `Results<,>`, so `Ok`/`NotFound` branches assert directly with no host and no database.

## Result

```
test/
  UnitTests/          8  → 79 tests   (pure, in-memory, no host, no DB)
  IntegrationTests/   6  tests        (unchanged)
  FunctionalTests/    48 → 20 tests   (genuinely HTTP-through-WebApplicationFactory)
  AppHost.Tests/       1 test         (unchanged)
                       63 → 106 total
```

`Moq` is gone from the solution. Every `UnitTests` method follows `Given_When_Then`. `dotnet format --verify-no-changes` passes.

## Non-goals (deliberately deferred, see spec)

- **Coverage config.** `testconfig.json` is untouched. 82% of counted lines are generated code (OpenAPI transformers, JSON source-gen context, minimal-API route builder, Mapperly), so the reported 68% → ~69% delta looks unimpressive; against hand-written code only it's ~91%. Excluding `[GeneratedCode]`/`[ExcludeFromCodeCoverage]` would show ~89%, but that's a metric-rebasing change that needs its owner's sign-off — recorded in the spec, not shipped here.
- **Shouldly, Testcontainers/Respawn, TestAuthHandler, CI restructuring, Postgres.** Each needs its own design cycle (Slices 2–4).

## Known-open

The functional suite still corrupts its own seed data (`DeleteOrder_ValidId_ReturnsNoContent` deletes Order 3, `CreateOrder_ValidDto_ReturnsCreatedOrder` leaks rows), so a second consecutive **local** run fails until reseeded:

```bash
docker exec -w /mssql-server-setup-scripts.d moneygroup-mssql-1 bash ./reset.sh
```

CI is unaffected — its container is recreated per run and self-seeds via `run_custom_setup.sh`. This is deliberate: Slice 2 (Testcontainers + Respawn) fixes the root cause; a stopgap here would be throwaway.

## Verification

- `dotnet test --solution MoneyGroup.slnx` (after seed reset): **106 total, 0 failed, 2 skipped** — reproduced multiple times across the branch.
- Test-count parity asserted at every phase boundary (63 before/after Phase 1 and 2; each individual task's expected count checked before committing).
- `dotnet format MoneyGroup.slnx --verify-no-changes -v diag --severity info`: clean.
- `grep -rn "Moq" test --include=*.cs --include=*.csproj`: empty.
- Coverage measured post-merge: 2570/3716 lines (69.16%), consistent with the spec's ~68.4% prediction; denominator unchanged, confirming `testconfig.json` was not touched.
- No `#pragma warning disable` added; `TreatWarningsAsErrors=true` respected throughout — the CA1859 pragma present before this PR was retired, not suppressed further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
